### PR TITLE
Accurate bar charts, starting at 0, with trend line

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -276,6 +276,9 @@
     "positiveTests": {
       "title": "Total tested positive",
       "hint": "Graph showing daily positive test results over time"
+    },
+    "legend": {
+      "averageLine": "7 day average"
     }
   },
   "symptomsHistory": {

--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -1,0 +1,139 @@
+import React, {FC} from 'react';
+import {ViewStyle, StyleProp, StyleSheet} from 'react-native';
+import {Rect, G, Path} from 'react-native-svg';
+import {BarChart, Grid} from 'react-native-svg-charts';
+import {colors} from 'theme';
+import {line, curveMonotoneX} from 'd3-shape';
+
+interface BarChartContentProps {
+  chartData: number[];
+  contentInset: {top: number; bottom: number};
+  rollingAverage?: number;
+  primaryColor?: string;
+  backgroundColor?: string;
+  secondaryColor?: string;
+  cornerRoundness?: number;
+  gapPercent?: number;
+  style?: StyleProp<ViewStyle>;
+  yMax?: number;
+}
+
+interface BarChildProps {
+  x: (index: number) => number;
+  y: (value: number) => number;
+  bandwidth: number; // width of bar
+  data: number[];
+}
+
+export const BarChartContent: FC<BarChartContentProps> = ({
+  chartData,
+  contentInset,
+  rollingAverage = 0,
+  primaryColor = colors.orange,
+  secondaryColor = colors.lightOrange,
+  backgroundColor = colors.white,
+  cornerRoundness = 4,
+  gapPercent = 25,
+  style,
+  yMax
+}) => {
+  const RoundedBarToppers: FC<BarChildProps> = (props) => {
+    const {x, y, bandwidth, data} = props;
+    return (
+      <G>
+        {data.map((value, index) => (
+          <Rect
+            x={x(index)}
+            y={y(value) - cornerRoundness}
+            rx={cornerRoundness}
+            ry={cornerRoundness}
+            width={bandwidth}
+            height={cornerRoundness * 2} // Height of the Rect
+            fill={secondaryColor}
+            key={`bar-${index}`}
+          />
+        ))}
+      </G>
+    );
+  };
+
+  const TrendLine: FC<BarChildProps> = (props) => {
+    const {x, y, bandwidth} = props;
+    const rollingData = rollingAverage
+      ? chartData.map((_, index) => {
+          const total = chartData
+            .slice(index - rollingAverage, index)
+            .reduce((sum, num) => sum + num, 0);
+          return total / rollingAverage;
+        })
+      : chartData;
+
+    const lineGenerator = line();
+    lineGenerator.curve(curveMonotoneX);
+    const pathDef = lineGenerator(
+      rollingData
+//        .slice(rollingAverage)
+        .map((value, index) => [x(index) + bandwidth / 2, y(value)])
+    );
+    return pathDef ? (
+      <Path
+        d={pathDef}
+        stroke={primaryColor}
+        strokeWidth={3}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    ) : null;
+  };
+
+  // Covers ends of bars hanging below line due to corner roundnesss
+  const XAxisTrim: FC<BarChildProps> = (props) => {
+    if (!props) {
+      return null;
+    }
+    const {x, y, bandwidth, data} = props;
+    return (
+      <Rect
+        x={x && x(0)}
+        y={y && y(0) - cornerRoundness}
+        width={x(data?.length - 1) + bandwidth} // Full width of x axis
+        height={cornerRoundness + 2}
+        fill={backgroundColor}
+      />
+    );
+  };
+
+  return (
+    <BarChart
+      style={style}
+      data={chartData} //.slice(rollingAverage)}
+      gridMin={0}
+      numberOfTicks={3}
+      spacingInner={gapPercent / 100}
+      spacingOuter={gapPercent / 100}
+      contentInset={{
+        top: contentInset.top + cornerRoundness,
+        bottom: contentInset.bottom - cornerRoundness
+      }}
+      yMax={yMax}
+      svg={{
+        fill: secondaryColor
+      }}>
+      <Grid
+        svg={{
+          y: 0 - cornerRoundness,
+          strokeWidth: 1,
+          stroke: colors.dot,
+          strokeDasharray: [5, 3],
+          strokeDashoffset: 0
+        }}
+      />
+      {/* @ts-ignore: gets BarChildProps from BarChart parent */}
+      <RoundedBarToppers />
+      {/* @ts-ignore: gets BarChildProps from BarChart parent */}
+      <XAxisTrim />
+      {/* @ts-ignore: gets BarChildProps from BarChart parent */}
+      <TrendLine />
+    </BarChart>
+  );
+};

--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -9,6 +9,7 @@ interface BarChartContentProps {
   chartData: number[];
   contentInset: {top: number; bottom: number};
   rollingAverage?: number;
+  days?: number;
   primaryColor?: string;
   backgroundColor?: string;
   secondaryColor?: string;
@@ -38,6 +39,10 @@ export const BarChartContent: FC<BarChartContentProps> = ({
   style,
   yMax
 }) => {
+  const rollingOffset = Math.max(0, rollingAverage - 1);
+  const startPoint = Math.max(0, chartData.length - (days + rollingOffset));
+  const visibleChartData = chartData.slice(startPoint);
+
   const RoundedBarToppers: FC<BarChildProps> = (props) => {
     const {x, y, bandwidth, data} = props;
     return (
@@ -60,22 +65,14 @@ export const BarChartContent: FC<BarChartContentProps> = ({
 
   const TrendLine: FC<BarChildProps> = (props) => {
     const {x, y, bandwidth} = props;
-    const rollingOffset = Math.max(
-      0,
-      chartData.length - (days + rollingAverage - 1)
-    );
-    const shownValues = chartData.slice(rollingOffset);
     const rollingData = rollingAverage
-      ? shownValues.map((_, index) => {
-          const startPoint =
+      ? visibleChartData.map((_, index) => {
+          const avStart =
             rollingAverage + index > chartData.length
               ? Math.max(0, index - rollingAverage)
               : index;
-          const endPoint = Math.min(
-            rollingAverage + index,
-            chartData.length - 1
-          );
-          const avValues = chartData.slice(startPoint, endPoint);
+          const avEnd = Math.min(rollingAverage + index, chartData.length - 1);
+          const avValues = chartData.slice(avStart, avEnd);
           const total = avValues.reduce((sum, num) => sum + num, 0);
           return total / avValues.length;
         })
@@ -114,13 +111,10 @@ export const BarChartContent: FC<BarChartContentProps> = ({
     );
   };
 
-  const rollingOffset = Math.max(0, rollingAverage - 1);
-  const startPoint = Math.max(0, days - chartData.length + rollingOffset);
-
   return (
     <BarChart
       style={style}
-      data={chartData.slice(startPoint)}
+      data={visibleChartData}
       gridMin={0}
       numberOfTicks={3}
       spacingInner={gapPercent / 100}

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -16,6 +16,7 @@ interface TrackerBarChartProps {
   yesterday?: string;
   data: any;
   days?: number;
+  rollingAverage?: number;
   intervalsCount?: number;
   backgroundColor?: string;
   primaryColor?: string;
@@ -23,7 +24,6 @@ interface TrackerBarChartProps {
   quantityKey: string;
 }
 
-const rolling = 7;
 const legendLineSize = 24;
 const nbsp = ' ';
 
@@ -41,24 +41,16 @@ function formatLabel(value: number) {
   return value;
 }
 
-function trimData(chartData: any[], days: number) {
-  // REMOVE this is to get 30 values before the API is updated
-  while (chartData.length < days + rolling) {
-    chartData = [...chartData.map((d) => d * Math.random()), ...chartData];
-  }
-  if (chartData.length > days + rolling) {
-    chartData = chartData.slice(0, days + 1);
-  }
-  return chartData;
+function trimData(data: any[], days: number, rolling: number) {
+  const rollingOffset = Math.max(0, rolling - 1);
+  const trimLength = days + rollingOffset;
+  const excessLength = data.length - trimLength;
+  return excessLength > 0 ? data.slice(excessLength) : data;
 }
 
 function trimAxisData(axisData: any[], days: number) {
-  const lastDate = axisData[axisData.length - 1];
-  return Array(days + 1)
-    .fill('')
-    .map((_, index) => {
-      return sub(new Date(lastDate), {days: days - index - 1});
-    });
+  const excessLength = axisData.length - days;
+  return excessLength > 0 ? axisData.slice(excessLength) : axisData;
 }
 
 export const TrackerBarChart: FC<TrackerBarChartProps> = ({
@@ -66,6 +58,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   data,
   hint,
   yesterday,
+  rollingAverage = 7,
   days = 30,
   intervalsCount = 6,
   primaryColor,
@@ -109,7 +102,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
     });
   }
 
-  chartData = trimData(chartData, days);
+  chartData = trimData(chartData, days, rollingAverage);
   axisData = trimAxisData(axisData, days);
 
   if (!chartData.length || !axisData.length) {
@@ -165,7 +158,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
             primaryColor={primaryColor}
             secondaryColor={secondaryColor}
             backgroundColor={backgroundColor}
-            rollingAverage={rolling}
+            rollingAverage={rollingAverage}
             yMax={yMax}
           />
           <XAxis

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -7,7 +7,7 @@ import * as shape from 'd3-shape';
 
 import {text, colors} from 'theme';
 
-interface TrackerAreaChartProps {
+interface TrackerBarChartProps {
   title?: string;
   label?: string;
   hint?: string;
@@ -34,7 +34,7 @@ function formatLabel(value: number) {
   return value;
 }
 
-export const TrackerAreaChart: FC<TrackerAreaChartProps> = ({
+export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   title,
   data,
   hint,

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -101,9 +101,10 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
       chartData.push(record[quantityKey]);
     });
   }
+  const daysLimit = Math.min(days, chartData.length);
 
-  chartData = trimData(chartData, days, rollingAverage);
-  axisData = trimAxisData(axisData, days);
+  chartData = trimData(chartData, daysLimit, rollingAverage);
+  axisData = trimAxisData(axisData, daysLimit);
 
   if (!chartData.length || !axisData.length) {
     return null;
@@ -152,6 +153,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
         <View style={styles.chartingCol}>
           <BarChartContent
             chartData={chartData}
+            days={daysLimit}
             cornerRoundness={2}
             contentInset={contentInset}
             style={styles.chart}
@@ -166,7 +168,6 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
             contentInset={contentInset}
             svg={{...xAxisSvg, y: 3}}
             formatLabel={(_, index) => {
-              console.log(index, 'xAxisDates[index]', axisData[index]);
               if (index % intervalsCount) {
                 return '';
               }
@@ -179,7 +180,6 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
             contentInset={contentInset}
             svg={xAxisSvg}
             formatLabel={(_, index) => {
-              console.log(index, 'xAxisDates[index]', axisData[index]);
               if (index % intervalsCount) {
                 return '';
               }

--- a/src/components/views/dashboard.tsx
+++ b/src/components/views/dashboard.tsx
@@ -13,7 +13,7 @@ import {Scrollable} from 'components/templates/scrollable';
 import {Spacing} from 'components/atoms/spacing';
 import {Toast} from 'components/atoms/toast';
 import {TracingAvailable} from 'components/molecules/tracing-available';
-import {TrackerAreaChart} from 'components/molecules/area-chart';
+import {TrackerBarChart} from 'src/components/molecules/bar-chart';
 import {useApplication} from 'providers/context';
 import {useAppState} from 'hooks/app-state';
 import {useSymptomChecker} from 'hooks/symptom-checker';
@@ -129,7 +129,7 @@ export const Dashboard: FC<any> = ({navigation}) => {
           {isChartDataAvailable && (
             <>
               <Card padding={{h: 12}}>
-                <TrackerAreaChart
+                <TrackerBarChart
                   title={t('charts:tests:title')}
                   hint={t('charts:tests:hint')}
                   quantityKey="total_number_of_tests"
@@ -146,7 +146,7 @@ export const Dashboard: FC<any> = ({navigation}) => {
             <>
               <Spacing s={20} />
               <Card padding={{h: 12}}>
-                <TrackerAreaChart
+                <TrackerBarChart
                   title={t('charts:positiveTests:title')}
                   hint={t('charts:positiveTests:hint')}
                   quantityKey="new_positives"

--- a/src/components/views/dashboard.tsx
+++ b/src/components/views/dashboard.tsx
@@ -13,7 +13,7 @@ import {Scrollable} from 'components/templates/scrollable';
 import {Spacing} from 'components/atoms/spacing';
 import {Toast} from 'components/atoms/toast';
 import {TracingAvailable} from 'components/molecules/tracing-available';
-import {TrackerBarChart} from 'src/components/molecules/bar-chart';
+import {TrackerBarChart} from 'components/molecules/bar-chart';
 import {useApplication} from 'providers/context';
 import {useAppState} from 'hooks/app-state';
 import {useSymptomChecker} from 'hooks/symptom-checker';

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -35,7 +35,8 @@ export const colors = {
   lightpurple: '#fff37a',
   mildpurple: '#fff16f',
   darkerpurple: '#FFDA1A', // review & merge to purple
-  orange: '#FF8248', // review as used only in toast
+  orange: '#FF8248',
+  lightOrange: '#FFC0A3',
   white,
   red,
   teal,


### PR DESCRIPTION
Several recent issues are closely related so I'll work on them together:

- [x] Switch charts to vertical bars https://github.com/project-vagabond/covid-green-app/issues/81
  - [x] Add 7-day rolling average line
  - [x] Add labelling to line (needs input on text)
- [x] Start the charts' Y-axis at 0 https://github.com/project-vagabond/covid-green-app/issues/80
- [x] Ensure the charts accurately represent the latest API data https://github.com/project-vagabond/covid-green-app/issues/79
- [x] No non-integers in y axis labels, and don't show very low numbers as spikes https://github.com/project-vagabond/covid-green-app/issues/94
- [x] Accomodate varied charting periods (change to 30 days as per  https://github.com/project-vagabond/covid-green-app/issues/78 needs to be done on the API side)
 