### PR TITLE
Prevent app crash on re-opening to an unmounted view

### DIFF
--- a/src/components/atoms/heading.tsx
+++ b/src/components/atoms/heading.tsx
@@ -31,7 +31,10 @@ export const Heading: React.FC<HeadingProps> = ({
     if (ref.current && accessibilityFocus) {
       const tag = findNodeHandle(ref.current);
       if (tag) {
-        setTimeout(() => AccessibilityInfo.setAccessibilityFocus(tag), 200);
+        setTimeout(
+          () => ref.current && AccessibilityInfo.setAccessibilityFocus(tag),
+          200
+        );
       }
     }
   }, []);
@@ -40,7 +43,10 @@ export const Heading: React.FC<HeadingProps> = ({
     if (isFocused && accessibilityRefocus && ref.current) {
       const tag = findNodeHandle(ref.current);
       if (tag) {
-        setTimeout(() => AccessibilityInfo.setAccessibilityFocus(tag), 200);
+        setTimeout(
+          () => ref.current && AccessibilityInfo.setAccessibilityFocus(tag),
+          200
+        );
       }
     }
   });

--- a/src/components/molecules/check-in-card.tsx
+++ b/src/components/molecules/check-in-card.tsx
@@ -30,7 +30,10 @@ export const CheckInCard: FC<CheckInCardProps> = ({
     if (ref.current && accessibilityFocus) {
       const tag = findNodeHandle(ref.current);
       if (tag) {
-        setTimeout(() => AccessibilityInfo.setAccessibilityFocus(tag), 250);
+        setTimeout(
+          () => ref.current && AccessibilityInfo.setAccessibilityFocus(tag),
+          250
+        );
       }
     }
   }, []);
@@ -39,7 +42,10 @@ export const CheckInCard: FC<CheckInCardProps> = ({
     if (isFocused && accessibilityRefocus && ref.current) {
       const tag = findNodeHandle(ref.current);
       if (tag) {
-        setTimeout(() => AccessibilityInfo.setAccessibilityFocus(tag), 250);
+        setTimeout(
+          () => ref.current && AccessibilityInfo.setAccessibilityFocus(tag),
+          250
+        );
       }
     }
   });

--- a/src/components/views/get-started.tsx
+++ b/src/components/views/get-started.tsx
@@ -47,7 +47,10 @@ export const GetStarted = ({navigation}: GetStartedProps) => {
     if (firstEl.current) {
       const tag = findNodeHandle(firstEl.current);
       if (tag) {
-        setTimeout(() => AccessibilityInfo.setAccessibilityFocus(tag), 250);
+        setTimeout(
+          () => firstEl.current && AccessibilityInfo.setAccessibilityFocus(tag),
+          250
+        );
       }
     }
   }, []);


### PR DESCRIPTION
I keep seeing this error on Android - re-opening the closed app to certain views crashes because the timeout that sets accessibility focus keeps a reference to a node that sometimes doesn't exist when the timeout resolves.

No issue for it, just an error I keep seeing.