### PR TITLE
disable feeling well button when symptoms are selected

### DIFF
--- a/src/components/atoms/button.tsx
+++ b/src/components/atoms/button.tsx
@@ -54,6 +54,11 @@ export const Button: React.FC<ButtonProps> = ({
     // this should be enough for the moment
     backgroundColor += '66';
     foregroundColor += '66';
+    if (type === 'empty') {
+      backgroundColor = colors.gray;
+      foregroundColor = colors.gray;
+      textColor = colors.text;
+    }
   }
 
   const pressHandlers = disabled

--- a/src/components/views/symptom-checker/symptoms.tsx
+++ b/src/components/views/symptom-checker/symptoms.tsx
@@ -115,7 +115,11 @@ export const CheckInSymptoms = () => {
           'checker:symptoms:subtitle'
         )}`}</Text>
         <Spacing s={36} />
-        <Button width="100%" type="empty" onPress={onFeelingWell}>
+        <Button
+          width="100%"
+          type="empty"
+          onPress={onFeelingWell}
+          disabled={!!enableContinue}>
           {t('checker:feelingWell')}
         </Button>
         <Spacing s={36} />


### PR DESCRIPTION
Issue: https://github.com/project-vagabond/covid-green-app/issues/52

Asked @stuartgiles wether we should change empty to primary button. Not really needed for this PR, but i'll include if I get  an answer in time