### PR TITLE
Fix chart x axis on small data sets

### DIFF
--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -37,6 +37,7 @@ export const BarChartContent: FC<BarChartContentProps> = ({
   cornerRoundness = 4,
   gapPercent = 25,
   style,
+  scale,
   yMax
 }) => {
   const rollingOffset = Math.max(0, rollingAverage - 1);
@@ -116,6 +117,7 @@ export const BarChartContent: FC<BarChartContentProps> = ({
       style={style}
       data={visibleChartData}
       gridMin={0}
+      scale={scale}
       numberOfTicks={3}
       spacingInner={gapPercent / 100}
       spacingOuter={gapPercent / 100}

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -3,11 +3,12 @@ import {StyleSheet, View, Text} from 'react-native';
 import Svg, {Line} from 'react-native-svg';
 import {YAxis, XAxis} from 'react-native-svg-charts';
 import {useTranslation} from 'react-i18next';
-import {format, sub} from 'date-fns';
+import {format} from 'date-fns';
 
 import {text, colors} from 'theme';
 import {BarChartContent} from 'components/atoms/bar-chart-content';
 import {Spacing} from 'components/atoms/spacing';
+import {scaleBand} from 'd3-scale';
 
 interface TrackerBarChartProps {
   title?: string;
@@ -155,6 +156,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
             chartData={chartData}
             days={daysLimit}
             cornerRoundness={2}
+            scale={scaleBand}
             contentInset={contentInset}
             style={styles.chart}
             primaryColor={primaryColor}
@@ -166,9 +168,10 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
           <XAxis
             data={chartData}
             contentInset={contentInset}
+            scale={scaleBand}
             svg={{...xAxisSvg, y: 3}}
             formatLabel={(_, index) => {
-              if (index % intervalsCount) {
+              if (chartData.length > 10 && index % intervalsCount) {
                 return '';
               }
               const date = new Date(axisData[index]);
@@ -178,6 +181,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
           <XAxis
             data={chartData}
             contentInset={contentInset}
+            scale={scaleBand}
             svg={xAxisSvg}
             formatLabel={(_, index) => {
               if (index % intervalsCount) {


### PR DESCRIPTION
It looks like we'll have some testing being done on the app while it's still only getting 7 days of data from the API.

The X axis was designed to look right at closer to 30 data points. This adds a bit more flexibility to it so that it looks right for the 24 hours or so in which people without this contextual knowledge will be testing the app while it gets 7 days of data from the API.

<img width=400 src="https://user-images.githubusercontent.com/29628323/91478764-565f9880-e898-11ea-911e-a787895a4169.jpg" />
