### PR TITLE
Allow android devices to use test token

### DIFF
--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -27,7 +27,13 @@ interface CheckIn {
 export type UploadResponse = Response | undefined;
 
 export const verify = async (nonce: string) => {
-  if (Platform.OS === 'android') {
+  if (ENV !== 'production' && TEST_TOKEN) {
+    console.log('using test token', TEST_TOKEN);
+    return {
+      platform: 'test',
+      deviceVerificationPayload: TEST_TOKEN
+    };
+  } else if (Platform.OS === 'android') {
     console.log(SAFETYNET_KEY);
     console.log(urls.api);
     try {
@@ -44,13 +50,6 @@ export const verify = async (nonce: string) => {
       throw err;
     }
   } else {
-    if (ENV !== 'production' && TEST_TOKEN) {
-      console.log('using test token', TEST_TOKEN);
-      return {
-        platform: 'test',
-        deviceVerificationPayload: TEST_TOKEN
-      };
-    }
     return {
       platform: 'ios',
       deviceVerificationPayload: await RNIOS11DeviceCheck.getToken()


### PR DESCRIPTION
I had a lot of trouble connecting to the `dev` API. Turns out, the app only used a `TEST_TOKEN` from non-prod env vars on iOS.

With this, connecting to the `dev` API works if a `TEST_TOKEN` is provided in the `.env` and the environment is not production.