### PR TITLE
Fix language switching, updating text from API when language changes

### DIFF
--- a/src/components/views/data-protection-policy.tsx
+++ b/src/components/views/data-protection-policy.tsx
@@ -8,7 +8,7 @@ import {colors, text} from 'theme';
 import {Link} from 'components/atoms/link';
 import {Markdown} from 'components/atoms/markdown';
 import {Scrollable} from 'components/templates/scrollable';
-import {useSettings} from 'providers/settings';
+import {useDbText} from 'providers/settings';
 
 const styles = StyleSheet.create({
   privacy: {
@@ -40,7 +40,7 @@ export const DataProtectionLink = () => {
 };
 
 export const DataProtectionPolicy = () => {
-  const {dpinText} = useSettings();
+  const {dpinText} = useDbText();
   const {t} = useTranslation();
 
   return (
@@ -51,7 +51,7 @@ export const DataProtectionPolicy = () => {
 };
 
 export const TermsAndConditions = () => {
-  const {tandcText} = useSettings();
+  const {tandcText} = useDbText();
   const {t} = useTranslation();
 
   return (

--- a/src/components/views/settings/check-in.tsx
+++ b/src/components/views/settings/check-in.tsx
@@ -3,7 +3,7 @@ import {Text, ScrollView} from 'react-native';
 import {useTranslation} from 'react-i18next';
 
 import {useApplication} from 'providers/context';
-import {useSettings} from 'providers/settings';
+import {useDbText} from 'providers/settings';
 import {useSymptomChecker} from 'hooks/symptom-checker';
 
 import {Spacing, Separator} from 'components/atoms/layout';
@@ -38,7 +38,7 @@ export const CheckInSettings: React.FC<CheckInSettingsProps> = ({
     ethnicityOptions,
     ageRangeOptions,
     countiesOptions
-  } = useSettings();
+  } = useDbText();
   const app = useApplication();
   const {getNextScreen} = useSymptomChecker();
 

--- a/src/components/views/symptom-checker/final.tsx
+++ b/src/components/views/symptom-checker/final.tsx
@@ -9,7 +9,7 @@ import {useTranslation} from 'react-i18next';
 import {useExposure} from 'react-native-exposure-notification-service';
 
 import {useApplication} from 'providers/context';
-import {useSettings} from 'providers/settings';
+import {useDbText} from 'providers/settings';
 import {useAppState} from 'hooks/app-state';
 import {Heading} from 'components/atoms/heading';
 import {ResultCard} from 'components/molecules/result-card';
@@ -35,7 +35,7 @@ export const CheckInFinal: FC<any> = ({route}) => {
   const isFocused = useIsFocused();
   const [appState] = useAppState();
 
-  const {checkerThankYouText} = useSettings();
+  const {checkerThankYouText} = useDbText();
   const {completedChecker, checks, verifyCheckerStatus} = useApplication();
   const {readPermissions} = useExposure();
 

--- a/src/components/views/symptom-checker/intro.tsx
+++ b/src/components/views/symptom-checker/intro.tsx
@@ -4,7 +4,7 @@ import {useTranslation} from 'react-i18next';
 import {useNavigation} from '@react-navigation/native';
 
 import {useApplication} from 'providers/context';
-import {useSettings} from 'providers/settings';
+import {useDbText} from 'providers/settings';
 import {useSymptomChecker} from 'hooks/symptom-checker';
 
 import {Spacing, Separator} from 'components/atoms/layout';
@@ -33,7 +33,7 @@ export function CheckInIntro() {
     ethnicityOptions,
     ageRangeOptions,
     countiesOptions
-  } = useSettings();
+  } = useDbText();
   const {getNextScreen} = useSymptomChecker();
 
   const [state, setState] = useState<IntroState>({

--- a/src/providers/settings.tsx
+++ b/src/providers/settings.tsx
@@ -3,8 +3,11 @@ import React, {
   ReactNode,
   createContext,
   useContext,
-  useState,
-  useEffect
+  useEffect,
+  useCallback,
+  useReducer,
+  Reducer,
+  useMemo
 } from 'react';
 import AsyncStorage from '@react-native-community/async-storage';
 import i18n, {TFunction} from 'i18next';
@@ -50,6 +53,10 @@ interface SettingsContextValue {
   traceConfiguration: TraceConfiguration;
   user: string | null;
   consent: string | null;
+  getTranslatedDbText: (t: TFunction) => DbTextContextValue;
+}
+
+interface DbTextContextValue {
   genderOptions: BasicItem[];
   raceOptions: BasicItem[];
   ethnicityOptions: BasicItem[];
@@ -60,7 +67,20 @@ interface SettingsContextValue {
   checkerThankYouText: CheckerThankYouText;
 }
 
-const defaultValue: SettingsContextValue = {
+type ApiSettings = Record<any, string>;
+
+const defaultDbText: DbTextContextValue = {
+  genderOptions: [],
+  raceOptions: [],
+  ethnicityOptions: [],
+  ageRangeOptions: [],
+  countiesOptions: [],
+  dpinText: '',
+  tandcText: '',
+  checkerThankYouText: {}
+};
+
+const defaultSettings: SettingsContextValue = {
   loaded: false,
   user: null,
   consent: null,
@@ -74,14 +94,7 @@ const defaultValue: SettingsContextValue = {
     fileLimit: 1,
     fileLimitiOS: 2
   },
-  genderOptions: [],
-  raceOptions: [],
-  ethnicityOptions: [],
-  ageRangeOptions: [],
-  countiesOptions: [],
-  dpinText: '',
-  tandcText: '',
-  checkerThankYouText: {}
+  getTranslatedDbText: () => defaultDbText
 };
 
 const getDbText = (apiSettings: any, key: string): any => {
@@ -104,16 +117,42 @@ const getDbText = (apiSettings: any, key: string): any => {
 };
 
 export const SettingsContext = createContext<SettingsContextValue>(
-  defaultValue
+  defaultSettings
 );
+export const DbTextContext = createContext<DbTextContextValue>(defaultDbText);
 
+interface SettingsReducerAction {
+  type: 'set' | 'loaded';
+  state?: SettingsContextValue;
+  loaded?: boolean;
+}
+
+const settingsReducer: Reducer<SettingsContextValue, SettingsReducerAction> = (
+  oldState,
+  {type, state, loaded}
+) => {
+  switch (type) {
+    case 'set':
+      return state || ({} as SettingsContextValue);
+    case 'loaded':
+      return {...oldState, loaded} as SettingsContextValue;
+  }
+};
 interface SettingsProviderProps {
   children: ReactNode;
 }
 
 export const SettingsProvider: FC<SettingsProviderProps> = ({children}) => {
   const {t} = useTranslation();
-  const [state, setState] = useState<SettingsContextValue>(defaultValue);
+  const [state, dispatchState] = useReducer(settingsReducer, defaultSettings);
+  const setState = useCallback(
+    (newState) => dispatchState({type: 'set', state: newState}),
+    []
+  );
+  const setIsLoaded = useCallback(
+    (loaded: boolean) => dispatchState({type: 'loaded', loaded}),
+    []
+  );
 
   useEffect(() => {
     const loadSettingsAsync = async () => {
@@ -122,7 +161,7 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({children}) => {
         'covidApp.checkInConsent'
       ]);
 
-      let apiSettings: Record<any, string>;
+      let apiSettings: ApiSettings;
       try {
         apiSettings = await api.loadSettings();
       } catch (e) {
@@ -130,7 +169,7 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({children}) => {
         apiSettings = {};
       }
 
-      const appConfig: AppConfig = {...defaultValue.appConfig};
+      const appConfig: AppConfig = {...defaultSettings.appConfig};
       if (apiSettings.checkInMaxAge) {
         appConfig.checkInMaxAge = Number(apiSettings.checkInMaxAge);
       }
@@ -139,7 +178,7 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({children}) => {
       }
 
       const tc: TraceConfiguration = {
-        ...defaultValue.traceConfiguration
+        ...defaultSettings.traceConfiguration
       };
       if (apiSettings.exposureCheckInterval) {
         tc.exposureCheckInterval = Number(apiSettings.exposureCheckInterval);
@@ -154,22 +193,7 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({children}) => {
         tc.fileLimitiOS = Number(apiSettings.fileLimitiOS);
       }
 
-      const dpinText =
-        getDbText(apiSettings, 'dpinText') || t('dataProtectionPolicy:text');
-
-      const tandcText =
-        getDbText(apiSettings, 'tandcText') || t('tandcPolicy:text');
-
-      const checkerThankYouText: CheckerThankYouText = Object.assign(
-        {
-          noSymptomsFeelingWell: t('checker:results:noSymptomsFeelingWell'),
-          noSymptomsNotFeelingWell: t(
-            'checker:results:noSymptomsNotFeelingWell'
-          ),
-          coronavirus: t('checker:results:coronavirus')
-        },
-        getDbText(apiSettings, 'checkerThankYouText')
-      );
+      const getTranslatedDbText = makeGetTranslatedDbText(apiSettings);
 
       setState({
         loaded: true,
@@ -177,34 +201,33 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({children}) => {
         consent: consent[1],
         appConfig,
         traceConfiguration: tc,
-        genderOptions: getGenderOptions(t),
-        raceOptions: getRaceOptions(t),
-        ethnicityOptions: getEthnicityOptions(t),
-        ageRangeOptions: getAgeRangeOptions(t),
-        countiesOptions: getCountiesOptions(t),
-        dpinText,
-        tandcText,
-        checkerThankYouText
+        getTranslatedDbText
       });
     };
 
     try {
       loadSettingsAsync();
     } catch (err) {
-      console.log(err, 'Error loading settings');
-      setState({...state, loaded: true});
+      setIsLoaded(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [setIsLoaded, setState]); // These never change; this useEffect runs on first mount only
 
+  // useSettings never re-renders after useEffect, useDbText re-renders when t changes
+  const translatedDbText = useMemo(() => state.getTranslatedDbText(t), [
+    state,
+    t
+  ]);
   return (
     <SettingsContext.Provider value={state}>
-      {children}
+      <DbTextContext.Provider value={translatedDbText}>
+        {children}
+      </DbTextContext.Provider>
     </SettingsContext.Provider>
   );
 };
 
 export const useSettings = () => useContext(SettingsContext);
+export const useDbText = () => useContext(DbTextContext);
 
 function getGenderOptions(t: TFunction): BasicItem[] {
   return [
@@ -224,7 +247,7 @@ function getRaceOptions(t: TFunction): BasicItem[] {
     {label: t('race:hawaiian'), value: 'hawaiian'},
     {label: t('race:white'), value: 'white'},
     {label: t('race:other'), value: 'unknown'},
-    {label: t('common:preferNotToSay'), value: 'u'}    
+    {label: t('common:preferNotToSay'), value: 'u'}
   ];
 }
 
@@ -237,7 +260,7 @@ function getEthnicityOptions(t: TFunction): BasicItem[] {
 }
 
 function getAgeRangeOptions(t: TFunction): AgeOption[] {
-  return [    
+  return [
     {label: '0-17', value: '0-17'},
     {label: '18-34', value: '18-34'},
     {label: '35-49', value: '35-49'},
@@ -253,4 +276,33 @@ function getCountiesOptions(t: TFunction): BasicItem[] {
     {label: t('county:notinny'), value: 'u'},
     ...counties.map((c) => ({label: c.county, value: c.code}))
   ];
+}
+
+function makeGetTranslatedDbText(apiSettings: ApiSettings) {
+  return (t: TFunction) => {
+    const dpinText =
+      getDbText(apiSettings, 'dpinText') || t('dataProtectionPolicy:text');
+
+    const tandcText =
+      getDbText(apiSettings, 'tandcText') || t('tandcPolicy:text');
+
+    const checkerThankYouText: CheckerThankYouText = Object.assign(
+      {
+        noSymptomsFeelingWell: t('checker:results:noSymptomsFeelingWell'),
+        noSymptomsNotFeelingWell: t('checker:results:noSymptomsNotFeelingWell'),
+        coronavirus: t('checker:results:coronavirus')
+      },
+      getDbText(apiSettings, 'checkerThankYouText')
+    );
+    return {
+      genderOptions: getGenderOptions(t),
+      raceOptions: getRaceOptions(t),
+      ethnicityOptions: getEthnicityOptions(t),
+      ageRangeOptions: getAgeRangeOptions(t),
+      countiesOptions: getCountiesOptions(t),
+      dpinText,
+      tandcText,
+      checkerThankYouText
+    };
+  };
 }

--- a/src/services/i18n/common.tsx
+++ b/src/services/i18n/common.tsx
@@ -1,9 +1,9 @@
 import en from 'assets/lang/en.json';
 import zh from 'assets/lang/zh.json';
 import ru from 'assets/lang/ru.json';
-import ht from 'assets/lang/ru.json';
-import bn from 'assets/lang/ru.json';
-import ko from 'assets/lang/ru.json';
+import ht from 'assets/lang/ht.json';
+import bn from 'assets/lang/bn.json';
+import ko from 'assets/lang/ko.json';
 import es from 'assets/lang/es.json';
 
 export const fallback = 'en';


### PR DESCRIPTION
@floridemai You'll recognise this 🙂 fixing the text from API not being re-translated when language changes.

Fixes everything we can fix in https://github.com/project-vagabond/covid-green-app/issues/122 without additional translation text

Second commit fixes https://github.com/project-vagabond/covid-green-app/issues/55