### PR TITLE
Decode any HTML entities in text from API

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "expo-secure-store": "~9.1.0",
     "expo-web-browser": "~8.3.1",
     "formik": "^2.1.4",
+    "html-entities": "^1.3.1",
     "i18next": "^19.6.3",
     "intl": "^1.2.5",
     "phone": "^2.4.14s",

--- a/src/providers/settings.tsx
+++ b/src/providers/settings.tsx
@@ -13,6 +13,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 import i18n, {TFunction} from 'i18next';
 import {useTranslation} from 'react-i18next';
 import {isObject} from 'formik';
+import {AllHtmlEntities} from 'html-entities';
 
 import * as api from 'services/api';
 import {fallback} from 'services/i18n/common';
@@ -110,9 +111,11 @@ const getDbText = (apiSettings: any, key: string): any => {
         .replace(/\\n/g, '\n')
         .replace(/(^|[^\n])\n(?!\n)/g, '$1\n\n');
     });
-    return item;
+    return AllHtmlEntities.decode(item);
   } else {
-    return data.replace(/\\n/g, '\n').replace(/(^|[^\n])\n(?!\n)/g, '$1\n\n');
+    return AllHtmlEntities.decode(
+      data.replace(/\\n/g, '\n').replace(/(^|[^\n])\n(?!\n)/g, '$1\n\n')
+    );
   }
 };
 


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/123

We can check our `.json` language files but we can't control the API content directly so this decodes any HTML entities that are sent to us escaped in the text. 