### PR TITLE
Chart feedback - bar colour and extra label

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -269,7 +269,8 @@
       "hint": "Graph showing daily positive test results over time"
     },
     "legend": {
-      "averageLine": "7 day average"
+      "averageLine": "7 day average",
+      "dailyTotal": "Daily total"
     }
   },
   "symptomsHistory": {

--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -11,9 +11,9 @@ interface BarChartContentProps {
   contentInset: {top: number; bottom: number};
   rollingAverage?: number;
   days?: number;
-  primaryColor?: string;
-  backgroundColor?: string;
-  secondaryColor?: string;
+  primaryColor: string;
+  backgroundColor: string;
+  secondaryColor: string;
   cornerRoundness?: number;
   gapPercent?: number;
   style?: StyleProp<ViewStyle>;
@@ -33,9 +33,9 @@ export const BarChartContent: FC<BarChartContentProps> = ({
   contentInset,
   rollingAverage = 0,
   days = chartData.length,
-  primaryColor = colors.orange,
-  secondaryColor = colors.lightOrange,
-  backgroundColor = colors.white,
+  primaryColor,
+  secondaryColor,
+  backgroundColor,
   cornerRoundness = 4,
   gapPercent = 25,
   style,

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -1,6 +1,6 @@
 import React, {FC} from 'react';
 import {StyleSheet, View, Text} from 'react-native';
-import Svg, {Line} from 'react-native-svg';
+import Svg, {Line, Rect} from 'react-native-svg';
 import {YAxis, XAxis} from 'react-native-svg-charts';
 import {useTranslation} from 'react-i18next';
 import {format} from 'date-fns';
@@ -25,7 +25,7 @@ interface TrackerBarChartProps {
   quantityKey: string;
 }
 
-const legendLineSize = 24;
+const legendItemSize = 16;
 const nbsp = ' ';
 
 function formatLabel(value: number) {
@@ -62,9 +62,9 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   rollingAverage = 7,
   days = 30,
   intervalsCount = 6,
-  primaryColor,
-  backgroundColor,
-  secondaryColor,
+  primaryColor = colors.orange,
+  secondaryColor = colors.tabs.highlighted,
+  backgroundColor = colors.white,
   quantityKey
 }) => {
   const {t} = useTranslation();
@@ -198,17 +198,31 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
       </View>
       <Spacing s={16} />
       <View style={styles.legend}>
-        <Svg height={legendLineSize} width={legendLineSize}>
-          <Line
-            x1={0}
-            x2={legendLineSize}
-            y={legendLineSize / 2}
-            strokeWidth={3}
-            stroke={colors.orange}
-          />
-        </Svg>
-        <Text style={styles.legendLabel}>{t('charts:legend:averageLine')}</Text>
-      </View>
+        <View style={styles.legend}>
+          <Svg height={legendItemSize} width={legendItemSize}>
+            <Rect
+              x={0}
+              y={0}
+              width={legendItemSize}
+              height={legendItemSize}
+              fill={secondaryColor}
+            />
+          </Svg>
+          <Text style={styles.legendLabel}>{t('charts:legend:dailyTotal')}</Text>
+        </View>
+        <View style={styles.legend}>
+          <Svg height={legendItemSize} width={legendItemSize}>
+            <Line
+              x1={0}
+              x2={legendItemSize}
+              y={legendItemSize / 2}
+              strokeWidth={3}
+              stroke={primaryColor}
+            />
+          </Svg>
+          <Text style={styles.legendLabel}>{t('charts:legend:averageLine')}</Text>
+        </View>
+       </View>
     </>
   );
 };
@@ -251,10 +265,12 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    marginHorizontal: 16
   },
   legendLabel: {
+    ...text.small,
     textAlign: 'left',
-    marginLeft: 16
+    marginLeft: 8
   }
 });


### PR DESCRIPTION
Fixes https://github.com/project-vagabond/covid-green-app/issues/134

Stuart tested the colour contrast across simulations for colour blindness types for accessibility.

<img width=420 src="https://user-images.githubusercontent.com/29628323/91561932-44333800-e934-11ea-8ba8-07358163f1ce.jpg" />
