### PR TITLE
fix initial screen flickering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -440,11 +440,7 @@ function Navigation({
   }, [app, exposureNotificationClicked]);
 
   if (app.initializing) {
-    return (
-      <View>
-        <Spinner visible />
-      </View>
-    );
+    return <Loading />;
   }
 
   return (

--- a/src/components/templates/base.tsx
+++ b/src/components/templates/base.tsx
@@ -10,6 +10,6 @@ export const Base: React.FC = ({children}) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.white
+    backgroundColor: colors.purple
   }
 });


### PR DESCRIPTION
From slack:
https://nearform.slack.com/archives/G017NH1BFCZ/p1598729586128200
@paul.negrutiu thanks for getting the splash screen up and running! That was nice to see. 
Can we make it display without the initial purple screen and without the white flash at the end? (Here's a video from Pixel 4XL). Would be important to display those branding elements for a bit longer.  Let me know if I should create an issue in GH.