### PR TITLE
Use Markdown on closeness-sensing body text

### DIFF
--- a/src/components/molecules/closeness-sensing/active.tsx
+++ b/src/components/molecules/closeness-sensing/active.tsx
@@ -34,7 +34,7 @@ export const Active: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
         {onboarding && (
           <>
             <Spacing s={20} />
-            <Markdown style={text.default}>
+            <Markdown>
               {t('closenessSensing:active:shareText')}
             </Markdown>
             <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/active.tsx
+++ b/src/components/molecules/closeness-sensing/active.tsx
@@ -7,6 +7,7 @@ import {shareApp} from 'components/atoms/navbar';
 import {Button} from 'components/atoms/button';
 import {Card} from 'components/atoms/card';
 import {Spacing} from 'components/atoms/layout';
+import {Markdown} from 'components/atoms/markdown';
 
 import {text} from 'theme';
 import {StateIcons} from 'assets/icons';
@@ -33,9 +34,9 @@ export const Active: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
         {onboarding && (
           <>
             <Spacing s={20} />
-            <Text style={text.default}>
+            <Markdown style={text.default}>
               {t('closenessSensing:active:shareText')}
-            </Text>
+            </Markdown>
             <Spacing s={24} />
             <View style={styles.buttonsWrapper}>
               <Button type="empty" onPress={() => shareApp(t)}>

--- a/src/components/molecules/closeness-sensing/active.tsx
+++ b/src/components/molecules/closeness-sensing/active.tsx
@@ -34,7 +34,7 @@ export const Active: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
         {onboarding && (
           <>
             <Spacing s={20} />
-            <Markdown>
+            <Markdown style={{}}>
               {t('closenessSensing:active:shareText')}
             </Markdown>
             <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/not-active-ios.tsx
+++ b/src/components/molecules/closeness-sensing/not-active-ios.tsx
@@ -6,6 +6,7 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'components/atoms/button';
 import {Card} from 'components/atoms/card';
 import {Spacing} from 'components/atoms/layout';
+import {Markdown} from 'components/atoms/markdown';
 
 import {text} from 'theme';
 import {StateIcons} from 'assets/icons';
@@ -42,13 +43,13 @@ export const NotActiveIOS: FC<NotActiveIOSProps> = ({
             {t('closenessSensing:notActiveIOS:title')}
           </Text>
           <Spacing s={20} />
-          <Text style={text.default}>
+          <Markdown style={text.default}>
             {t(
               `closenessSensing:notActiveIOS:${
                 exposureOff ? 'ens' : bluetoothOff ? 'bt' : 'text'
               }`
             )}
-          </Text>
+          </Markdown>
           <Spacing s={24} />
           <View style={sharedStyles.buttonsWrapper}>
             <Button

--- a/src/components/molecules/closeness-sensing/not-active-ios.tsx
+++ b/src/components/molecules/closeness-sensing/not-active-ios.tsx
@@ -43,7 +43,7 @@ export const NotActiveIOS: FC<NotActiveIOSProps> = ({
             {t('closenessSensing:notActiveIOS:title')}
           </Text>
           <Spacing s={20} />
-          <Markdown>
+          <Markdown style={{}}>
             {t(
               `closenessSensing:notActiveIOS:${
                 exposureOff ? 'ens' : bluetoothOff ? 'bt' : 'text'

--- a/src/components/molecules/closeness-sensing/not-active-ios.tsx
+++ b/src/components/molecules/closeness-sensing/not-active-ios.tsx
@@ -43,7 +43,7 @@ export const NotActiveIOS: FC<NotActiveIOSProps> = ({
             {t('closenessSensing:notActiveIOS:title')}
           </Text>
           <Spacing s={20} />
-          <Markdown style={text.default}>
+          <Markdown>
             {t(
               `closenessSensing:notActiveIOS:${
                 exposureOff ? 'ens' : bluetoothOff ? 'bt' : 'text'

--- a/src/components/molecules/closeness-sensing/not-authorized.tsx
+++ b/src/components/molecules/closeness-sensing/not-authorized.tsx
@@ -37,7 +37,7 @@ export const NotAuthorized: FC<{onboarding?: boolean}> = ({
             {t(`closenessSensing:notAuthorised:${Platform.OS}:title`)}
           </Text>
           <Spacing s={20} />
-          <Markdown>
+          <Markdown style={{}}>
             {t(`closenessSensing:notAuthorised:${Platform.OS}:text`)}
           </Markdown>
           <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/not-authorized.tsx
+++ b/src/components/molecules/closeness-sensing/not-authorized.tsx
@@ -37,7 +37,7 @@ export const NotAuthorized: FC<{onboarding?: boolean}> = ({
             {t(`closenessSensing:notAuthorised:${Platform.OS}:title`)}
           </Text>
           <Spacing s={20} />
-          <Markdown style={text.default}>
+          <Markdown>
             {t(`closenessSensing:notAuthorised:${Platform.OS}:text`)}
           </Markdown>
           <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/not-authorized.tsx
+++ b/src/components/molecules/closeness-sensing/not-authorized.tsx
@@ -7,6 +7,7 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'components/atoms/button';
 import {Card} from 'components/atoms/card';
 import {Spacing} from 'components/atoms/layout';
+import {Markdown} from 'components/atoms/markdown';
 
 import {text} from 'theme';
 import {StateIcons} from 'assets/icons';
@@ -36,9 +37,9 @@ export const NotAuthorized: FC<{onboarding?: boolean}> = ({
             {t(`closenessSensing:notAuthorised:${Platform.OS}:title`)}
           </Text>
           <Spacing s={20} />
-          <Text style={text.default}>
+          <Markdown style={text.default}>
             {t(`closenessSensing:notAuthorised:${Platform.OS}:text`)}
-          </Text>
+          </Markdown>
           <Spacing s={24} />
           <View style={sharedStyles.buttonsWrapper}>
             <Button onPress={onSetup}>

--- a/src/components/molecules/closeness-sensing/not-enabled-ios.tsx
+++ b/src/components/molecules/closeness-sensing/not-enabled-ios.tsx
@@ -31,7 +31,7 @@ export const NotEnabledIOS: FC<{onboarding?: boolean}> = ({
             {t('closenessSensing:notEnabledIOS:title')}
           </Text>
           <Spacing s={20} />
-          <Markdown>
+          <Markdown style={{}}>
             {t('closenessSensing:notEnabledIOS:text')}
           </Markdown>
           <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/not-enabled-ios.tsx
+++ b/src/components/molecules/closeness-sensing/not-enabled-ios.tsx
@@ -31,7 +31,7 @@ export const NotEnabledIOS: FC<{onboarding?: boolean}> = ({
             {t('closenessSensing:notEnabledIOS:title')}
           </Text>
           <Spacing s={20} />
-          <Markdown style={text.default}>
+          <Markdown>
             {t('closenessSensing:notEnabledIOS:text')}
           </Markdown>
           <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/not-enabled-ios.tsx
+++ b/src/components/molecules/closeness-sensing/not-enabled-ios.tsx
@@ -6,6 +6,7 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'components/atoms/button';
 import {Card} from 'components/atoms/card';
 import {Spacing} from 'components/atoms/layout';
+import {Markdown} from 'components/atoms/markdown';
 
 import {text} from 'theme';
 import {StateIcons} from 'assets/icons';
@@ -30,9 +31,9 @@ export const NotEnabledIOS: FC<{onboarding?: boolean}> = ({
             {t('closenessSensing:notEnabledIOS:title')}
           </Text>
           <Spacing s={20} />
-          <Text style={text.default}>
+          <Markdown style={text.default}>
             {t('closenessSensing:notEnabledIOS:text')}
-          </Text>
+          </Markdown>
           <Spacing s={24} />
           <View style={sharedStyles.buttonsWrapper}>
             <Button onPress={() => Linking.openURL('app-settings:')}>

--- a/src/components/molecules/closeness-sensing/not-supported.tsx
+++ b/src/components/molecules/closeness-sensing/not-supported.tsx
@@ -31,7 +31,7 @@ export const NotSupported: FC<{onboarding?: boolean}> = ({
             {t('closenessSensing:notSupported:title')}
           </Text>
           <Spacing s={20} />
-          <Markdown>
+          <Markdown style={{}}>
             {t('closenessSensing:notSupported:text')}
           </Markdown>
         </View>

--- a/src/components/molecules/closeness-sensing/not-supported.tsx
+++ b/src/components/molecules/closeness-sensing/not-supported.tsx
@@ -6,6 +6,7 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'components/atoms/button';
 import {Card} from 'components/atoms/card';
 import {Spacing} from 'components/atoms/layout';
+import {Markdown} from 'components/atoms/markdown';
 
 import {text} from 'theme';
 import {StateIcons} from 'assets/icons';
@@ -30,9 +31,9 @@ export const NotSupported: FC<{onboarding?: boolean}> = ({
             {t('closenessSensing:notSupported:title')}
           </Text>
           <Spacing s={20} />
-          <Text style={text.default}>
+          <Markdown style={text.default}>
             {t('closenessSensing:notSupported:text')}
-          </Text>
+          </Markdown>
         </View>
       </Card>
       {onboarding && (

--- a/src/components/molecules/closeness-sensing/not-supported.tsx
+++ b/src/components/molecules/closeness-sensing/not-supported.tsx
@@ -31,7 +31,7 @@ export const NotSupported: FC<{onboarding?: boolean}> = ({
             {t('closenessSensing:notSupported:title')}
           </Text>
           <Spacing s={20} />
-          <Markdown style={text.default}>
+          <Markdown>
             {t('closenessSensing:notSupported:text')}
           </Markdown>
         </View>

--- a/src/components/molecules/closeness-sensing/supported.tsx
+++ b/src/components/molecules/closeness-sensing/supported.tsx
@@ -44,7 +44,7 @@ export const Supported: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
             {t(`closenessSensing:supported:${Platform.OS}:title`)}
           </Text>
           <Spacing s={20} />
-          <Markdown style={text.default}>
+          <Markdown>
             {t(`closenessSensing:supported:${Platform.OS}:text`)}
           </Markdown>
           <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/supported.tsx
+++ b/src/components/molecules/closeness-sensing/supported.tsx
@@ -44,7 +44,7 @@ export const Supported: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
             {t(`closenessSensing:supported:${Platform.OS}:title`)}
           </Text>
           <Spacing s={20} />
-          <Markdown>
+          <Markdown style={{}}>
             {t(`closenessSensing:supported:${Platform.OS}:text`)}
           </Markdown>
           <Spacing s={24} />

--- a/src/components/molecules/closeness-sensing/supported.tsx
+++ b/src/components/molecules/closeness-sensing/supported.tsx
@@ -7,6 +7,7 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'components/atoms/button';
 import {Card} from 'components/atoms/card';
 import {Spacing} from 'components/atoms/layout';
+import {Markdown} from 'components/atoms/markdown';
 
 import {text} from 'theme';
 import {StateIcons} from 'assets/icons';
@@ -43,9 +44,9 @@ export const Supported: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
             {t(`closenessSensing:supported:${Platform.OS}:title`)}
           </Text>
           <Spacing s={20} />
-          <Text style={text.default}>
+          <Markdown style={text.default}>
             {t(`closenessSensing:supported:${Platform.OS}:text`)}
-          </Text>
+          </Markdown>
           <Spacing s={24} />
           <View style={sharedStyles.buttonsWrapper}>
             <Button onPress={checkForUpdatesHandler}>


### PR DESCRIPTION
Fixes https://github.com/project-vagabond/covid-green-app/issues/170

I've set all the closeness screens to use markdown for body text so it's easier to maintain: most don't use it currently but if a future text update changes that, it should just work.

<img width=350 src="https://user-images.githubusercontent.com/29628323/91723153-3deec700-eb93-11ea-9a04-8259727bd654.jpg" />