### PR TITLE
[WIP, low priority] Add touch states to card and dropdowns

### DIFF
--- a/src/components/atoms/card.tsx
+++ b/src/components/atoms/card.tsx
@@ -1,8 +1,9 @@
 import React, {ReactNode, FC} from 'react';
-import {StyleSheet, TouchableWithoutFeedback, View} from 'react-native';
+import {StyleSheet, Pressable, View} from 'react-native';
 
 import {colors, shadows} from 'theme';
 import {AppIcons} from 'assets/icons';
+import {TouchableHighlight} from 'react-native-gesture-handler';
 
 interface CardProps {
   type?: 'warning' | 'info' | 'empty';
@@ -61,9 +62,14 @@ export const Card: FC<CardProps> = ({
     </View>
   );
   return onPress ? (
-    <TouchableWithoutFeedback accessibilityRole="button" onPress={onPress}>
+    <TouchableHighlight
+      accessibilityRole="button"
+      onPress={onPress}
+      activeOpacity={0.9}
+      underlayColor={colors.darkGray}
+      style={styles.touchable}>
       {cardContent}
-    </TouchableWithoutFeedback>
+    </TouchableHighlight>
   ) : (
     cardContent
   );
@@ -77,6 +83,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center'
+  },
+  touchable: {
+    borderRadius: shadows.default.borderRadius
   },
   cardWarning: {
     borderWidth: 2,

--- a/src/components/atoms/card.tsx
+++ b/src/components/atoms/card.tsx
@@ -1,9 +1,9 @@
 import React, {ReactNode, FC} from 'react';
-import {StyleSheet, Pressable, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
+import {TouchableHighlight} from 'react-native-gesture-handler';
 
 import {colors, shadows} from 'theme';
 import {AppIcons} from 'assets/icons';
-import {TouchableHighlight} from 'react-native-gesture-handler';
 
 interface CardProps {
   type?: 'warning' | 'info' | 'empty';

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -7,6 +7,7 @@ import {
   ScrollView,
   View,
   Text,
+  TouchableHighlight,
   TextInput
 } from 'react-native';
 import Modal, {ModalProps} from 'react-native-modal';
@@ -17,7 +18,7 @@ import {BasicItem} from 'providers/settings';
 import {Spacing} from 'components/atoms/layout';
 
 import {text, colors} from 'theme';
-import Icons, {AppIcons} from 'assets/icons';
+import {AppIcons} from 'assets/icons';
 
 interface DropdownModalProps extends Partial<ModalProps> {
   close?: boolean;
@@ -37,7 +38,6 @@ interface DropdownModalProps extends Partial<ModalProps> {
 }
 
 export const DropdownModal: React.FC<DropdownModalProps> = ({
-  close,
   title,
   items,
   selectedValue,
@@ -67,8 +67,10 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
     }
 
     return (
-      <TouchableWithoutFeedback
+      <TouchableHighlight
         key={`item_${index}`}
+        activeOpacity={0.9}
+        underlayColor={colors.background}
         onPress={() => onSelect(value)}>
         <View
           style={[
@@ -89,7 +91,7 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
             </View>
           )}
         </View>
-      </TouchableWithoutFeedback>
+      </TouchableHighlight>
     );
   };
 

--- a/src/components/atoms/dropdown/selector.tsx
+++ b/src/components/atoms/dropdown/selector.tsx
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
-import {Text, View, TouchableWithoutFeedback, StyleSheet} from 'react-native';
+import {Text, View, StyleSheet} from 'react-native';
+import {TouchableHighlight} from 'react-native-gesture-handler';
 
 import {AppIcons} from 'assets/icons';
 import {BasicItem} from 'providers/settings';
@@ -57,9 +58,12 @@ export const SelectorDropdown: React.FC<DropdownProps> = ({
 
   return (
     <>
-      <TouchableWithoutFeedback
+      <TouchableHighlight
         accessibilityTraits={['button']}
         accessibilityComponentType="button"
+        activeOpacity={0.9}
+        underlayColor={colors.darkGray}
+        style={styles.touchable}
         onPress={() => setModalVisible(true)}>
         <View style={styles.container}>
           <View style={styles.content}>
@@ -69,7 +73,7 @@ export const SelectorDropdown: React.FC<DropdownProps> = ({
           </View>
           <AppIcons.Filter width={24} height={24} />
         </View>
-      </TouchableWithoutFeedback>
+      </TouchableHighlight>
       {isModalVisible && (
         <DropdownModal
           close
@@ -88,6 +92,9 @@ export const SelectorDropdown: React.FC<DropdownProps> = ({
 };
 
 const styles = StyleSheet.create({
+  touchable: {
+    borderRadius: 4
+  },
   container: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/172 

This covers cards only for now as adding touch states to tabs affects layout. We've had a bunch of small layout issues here and now would be a really bad time to risk introducing something on certain devices. Tabs change colour pretty much instantly on change anyway so if @helloantoine is happy with this we'll park them for now and come back to them if we have time to refactor the tabs.