### PR TITLE
removing the build number from the ios version

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -38,7 +38,7 @@ platform :ios do
   desc "Create a beta build"
   lane :beta_build do
     if ENV['BUILD_VERSION']
-        vmat = /v(?<version>\d+.\d+.\d+.(?<build>\d+)).*/.match(ENV["BUILD_VERSION"])        
+        vmat = /v(?<version>\d+.\d+.\d+).(?<build>\d+).*/.match(ENV["BUILD_VERSION"])        
         raise "Bad build version" if vmat.nil?
 
         build_version = vmat[:version]


### PR DESCRIPTION
Resolves ```[20:05:40]: [Transporter Error Output]: ERROR ITMS-90060: “This bundle is invalid. The value for key CFBundleShortVersionString ‘1.0.0.23’ in the Info.plist file at ‘Payload/COVID Alert NY.app’ must be a period-separated list of at most three non-negative integers. Please find more information about CFBundleShortVersionString at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring”```

