### PR TITLE
Update chart accessibility text

### DIFF
--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -95,8 +95,8 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
     if (isAxisLabelHidden(index)) {
       return summaryText;
     }
-    const stringStart = summaryText ? summaryText + ', ' : '';
-    return `${stringStart}${format(date, 'MMMM')} ${format(
+    const previousText = summaryText ? `${summaryText}, ` : '';
+    return `${previousText}${format(date, 'MMMM')} ${format(
       date,
       'do'
     )}: ${roundNumber(chartData[index])}${ySuffix}`;

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -119,7 +119,10 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   const showLegend = !!(rollingAverage || averagesData);
 
   return (
-    <>
+    <View
+      accessible
+      accessibilityLabel={description}
+      accessibilityHint={dataSummary}>
       {title && (
         <>
           <Text style={styles.title}>{title}</Text>
@@ -127,10 +130,9 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
         </>
       )}
       <View
-        style={styles.chartingRow}
-        accessible
-        accessibilityLabel={description}
-        accessibilityHint={dataSummary}>
+        accessibilityElementsHidden={true}
+        importantForAccessibility="no-hide-descendants"
+        style={styles.chartingRow}>
         <YAxis
           style={styles.yAxis}
           data={chartData}
@@ -224,7 +226,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
           </View>
         </>
       )}
-    </>
+    </View>
   );
 };
 

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -135,7 +135,7 @@ export const TrackerCharts: FC<TrackerChartsProps> = ({data, county = 'u'}) => {
           <Card padding={{h: 12}}>
             <TrackerBarChart
               title={t('charts:tests:title')}
-              hint={t('charts:tests:hint')}
+              description={t('charts:tests:hint')}
               axisData={testsData.axisData}
               chartData={testsData.chartData}
               averagesData={testsData.averagesData}
@@ -149,7 +149,7 @@ export const TrackerCharts: FC<TrackerChartsProps> = ({data, county = 'u'}) => {
           <Card padding={{h: 12}}>
             <TrackerBarChart
               title={t('charts:positivityPercent:title')}
-              hint={t('charts:positivityPercent:hint')}
+              description={t('charts:positivityPercent:hint')}
               axisData={percentData.axisData}
               chartData={percentData.chartData}
               averagesData={percentData.averagesData}
@@ -164,7 +164,7 @@ export const TrackerCharts: FC<TrackerChartsProps> = ({data, county = 'u'}) => {
         <Card padding={{h: 12}}>
           <TrackerBarChart
             title={t('charts:positiveTests:title')}
-            hint={t('charts:positiveTests:hint')}
+            description={t('charts:positiveTests:hint')}
             axisData={positivesData.axisData}
             chartData={positivesData.chartData}
             averagesData={positivesData.averagesData}


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/198 & https://github.com/project-vagabond/covid-green-app/issues/232

Gives accessibility tags based on figures for the points labelled on the x-axis, like:

```
{
  "accessibilityLabel": "Graph showing daily tests over time",
  "accessibilityHint": "August 3rd: 70993, August 9th: 54002, August 15th: 77692, August 21st: 94849, August 27th: 97826, August 31st: 76997"
}

{  
  "accessibilityLabel": "Graph showing the percent of daily tests with positive results over time",
  "accessibilityHint": "August 3rd: 1.05%, August 9th: 0.88%, August 15th: 0.78%, August 21st: 0.69%, August 27th: 0.65%, August 31st: 0.98%"
}

{
  "accessibilityLabel": "Graph showing daily positive test results over time",
  "accessibilityHint": "August 3rd: 746, August 9th: 476, August 15th: 607, August 21st: 653, August 27th: 636, August 31st: 754"
}

```

Also excludes inner chart content like axis labels from screen readers etc as this isn't useful info on its own and is covered more usefully by the new hint text.