### PR TITLE
Fastlane session extension

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -225,6 +225,7 @@ jobs:
         env:
           FASTLANE_USER: "${{ secrets.FASTLANE_USER }}"
         run: |
+          mkdir -p ~/.fastlane/spaceship/${FASTLANE_USER}
           echo "${{ secrets.FASTLANE_SESSION_FILE }}" | base64 -d -o ~/.fastlane/spaceship/${FASTLANE_USER}/cookie
           fastlane spaceauth -u $FASTLANE_USER |grep export > fastlane_session.sh
           source fastlane_session.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -225,6 +225,7 @@ jobs:
         env:
           FASTLANE_USER: "${{ secrets.FASTLANE_USER }}"
         run: |
+          cd ios
           . .env.default
           mkdir -p ~/.fastlane/spaceship/${FASTLANE_USER}
           echo "${{ secrets.FASTLANE_SESSION_FILE }}" | base64 -d -o ~/.fastlane/spaceship/${FASTLANE_USER}/cookie

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -225,10 +225,11 @@ jobs:
         env:
           FASTLANE_USER: "${{ secrets.FASTLANE_USER }}"
         run: |
+          . .env.default
           mkdir -p ~/.fastlane/spaceship/${FASTLANE_USER}
           echo "${{ secrets.FASTLANE_SESSION_FILE }}" | base64 -d -o ~/.fastlane/spaceship/${FASTLANE_USER}/cookie
           fastlane spaceauth -u $FASTLANE_USER |grep export > fastlane_session.sh
-          source fastlane_session.sh
+          . fastlane_session.sh
           echo "##[set-env name=FASTLANE_SESSION;]$FASTLANE_SESSION"
 
       - name: Setup Version variable

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -229,7 +229,7 @@ jobs:
           . .env.default
           mkdir -p ~/.fastlane/spaceship/${FASTLANE_USER}
           echo "${{ secrets.FASTLANE_SESSION_FILE }}" | base64 -d -o ~/.fastlane/spaceship/${FASTLANE_USER}/cookie
-          fastlane spaceauth -u $FASTLANE_USER |grep export > fastlane_session.sh
+          fastlane spaceauth -u $FASTLANE_USER |grep export |sed s/export\ // > fastlane_session.sh
           . fastlane_session.sh
           echo "##[set-env name=FASTLANE_SESSION;]$FASTLANE_SESSION"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -229,8 +229,8 @@ jobs:
           . .env.default
           mkdir -p ~/.fastlane/spaceship/${FASTLANE_USER}
           echo "${{ secrets.FASTLANE_SESSION_FILE }}" | base64 -d -o ~/.fastlane/spaceship/${FASTLANE_USER}/cookie
-          fastlane spaceauth -u $FASTLANE_USER |grep export |sed s/export\ // > fastlane_session.sh
-          . fastlane_session.sh
+          fastlane spaceauth -u $FASTLANE_USER |grep export | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g' |sed s/export\ // > fastlane_session.sh
+          . ./fastlane_session.sh
           echo "##[set-env name=FASTLANE_SESSION;]$FASTLANE_SESSION"
 
       - name: Setup Version variable

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -221,6 +221,15 @@ jobs:
           ruby-version: '2.6' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
           bundler-cache: true
 
+      - name: Setup Fastlane Spaceauth session
+        env:
+          FASTLANE_USER: "${{ secrets.FASTLANE_USER }}"
+        run: |
+          echo "${{ secrets.FASTLANE_SESSION_FILE }}" | base64 -d -o ~/.fastlane/spaceship/${FASTLANE_USER}/cookie
+          fastlane spaceauth -u $FASTLANE_USER |grep export > fastlane_session.sh
+          source fastlane_session.sh
+          echo "##[set-env name=FASTLANE_SESSION;]$FASTLANE_SESSION"
+
       - name: Setup Version variable
         run: |
           export BUILD_VERSION=${GITHUB_REF#refs/tags/}
@@ -235,7 +244,6 @@ jobs:
       - name: iOS Build
         env:
           FASTLANE_USER: "${{ secrets.FASTLANE_USER }}"
-          FASTLANE_SESSION: '${{ secrets.FASTLANE_SESSION }}'
         run: |
           cd ios 
           . .env.default
@@ -249,7 +257,6 @@ jobs:
       - name: iOS Testflight
         env:
           FASTLANE_USER: "${{ secrets.FASTLANE_USER }}"
-          FASTLANE_SESSION: '${{ secrets.FASTLANE_SESSION }}'
         run: |
           cd ios 
           . .env.default


### PR DESCRIPTION
Switching to a longer lived session cookie that will be refreshed when we build. This should last around 30 days per the fastlane documentation. The underlying session cookie will need to be updated periodically.