### PR TITLE
[256] added hitSlop to drowdown view to allow for less accurate touches

### DIFF
--- a/src/components/atoms/dropdown/basic.tsx
+++ b/src/components/atoms/dropdown/basic.tsx
@@ -70,7 +70,9 @@ export const Dropdown: React.FC<DropdownProps> = ({
         }
         accessibilityHint={placeholder}
         onPress={() => setModalVisible(true)}>
-        <View style={styles.container}>
+        <View
+          hitSlop={{right: 40, bottom: 20, top: 20}}
+          style={styles.container}>
           <View style={styles.content}>
             {label && (
               <>


### PR DESCRIPTION
Added hit slop to allow for better touch actions

Issue: [#256](https://github.com/project-vagabond/covid-green-app/issues/256)