### PR TITLE
Localise dates formatted by date-fns

### DIFF
--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -5,6 +5,7 @@ import {YAxis, XAxis} from 'react-native-svg-charts';
 import {useTranslation} from 'react-i18next';
 import {format} from 'date-fns';
 
+import {dateFnsLocales, getDateLocaleOptions} from 'services/i18n/date';
 import {text, colors} from 'theme';
 import {BarChartContent} from 'components/atoms/bar-chart-content';
 import {Spacing} from 'components/atoms/spacing';
@@ -75,7 +76,9 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   secondaryColor = '#ACAFC4',
   backgroundColor = colors.white
 }) => {
-  const {t} = useTranslation();
+  const {t, i18n} = useTranslation();
+  const dateLocale = getDateLocaleOptions(i18n);
+  const wideMonthLocales = ['bn'];
 
   const daysLimit = Math.min(days, chartData.length);
 
@@ -98,7 +101,8 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
     const previousText = summaryText ? `${summaryText}, ` : '';
     return `${previousText}${format(date, 'MMMM')} ${format(
       date,
-      'do'
+      'do',
+      dateLocale
     )}: ${roundNumber(chartData[index])}${ySuffix}`;
   }, '');
 
@@ -183,7 +187,8 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
               const date = new Date(axisData[index]);
               return `${index === 0 ? nbsp + nbsp : ''}${format(
                 date,
-                'MMM'
+                wideMonthLocales.includes(i18n.language) ? 'Mo' : 'MMM',
+                dateLocale
               ).toUpperCase()}${
                 index === axisData.length - 1 ? nbsp + nbsp : ''
               }`;

--- a/src/components/views/close-contact-alert.tsx
+++ b/src/components/views/close-contact-alert.tsx
@@ -11,6 +11,7 @@ import {Spacing} from 'components/atoms/layout';
 import {CallCard} from 'components/molecules/call-card';
 import {Scrollable} from 'components/templates/scrollable';
 
+import {getDateLocaleOptions} from 'services/i18n/date';
 import {text, colors} from 'theme';
 import {StateIcons} from 'assets/icons';
 
@@ -27,12 +28,13 @@ const markdownStyles = {
 };
 
 export const CloseContactAlert: FC = () => {
-  const {t} = useTranslation();
+  const {t, i18n} = useTranslation();
   const exposure = useExposure();
   const [closeContactDate, setCloseContactDate] = useState<string>('');
 
   useEffect(() => {
     async function getCloseContactDate() {
+      const dateLocale = getDateLocaleOptions(i18n);
       const contacts = await exposure.getCloseContacts();
       console.log(contacts);
       if (contacts && contacts.length) {
@@ -40,11 +42,12 @@ export const CloseContactAlert: FC = () => {
           new Date(Number(contacts[0].exposureAlertDate)),
           contacts[0].daysSinceLastExposure
         );
-        setCloseContactDate(format(exposureDate, 'MMMM dd, yyyy'));
+        setCloseContactDate(format(exposureDate, 'MMMM dd, yyyy', dateLocale));
       }
     }
     getCloseContactDate();
-  }, []);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [i18n]);
 
   PushNotification.setApplicationIconBadgeNumber(0);
 

--- a/src/components/views/symptoms-history.tsx
+++ b/src/components/views/symptoms-history.tsx
@@ -18,6 +18,7 @@ import {Scrollable} from 'components/templates/scrollable';
 import {Symptom, SymptomRecord} from 'constants/symptoms';
 import {text, colors} from 'theme';
 import {BubbleIcons} from 'assets/icons';
+import {getDateLocaleOptions} from 'services/i18n/date';
 
 interface SymptomListItem {
   value: Symptom;
@@ -25,7 +26,7 @@ interface SymptomListItem {
 }
 
 export const SymptomsHistory: FC<any> = ({navigation}) => {
-  const {t} = useTranslation();
+  const {t, i18n} = useTranslation();
   const isFocused = useIsFocused();
   const [appState] = useAppState();
   const {getNextScreen} = useSymptomChecker();
@@ -43,6 +44,8 @@ export const SymptomsHistory: FC<any> = ({navigation}) => {
       verifyCheckerStatus();
     }, [isFocused, appState, verifyCheckerStatus])
   );
+
+  const dateLocale = getDateLocaleOptions(i18n);
 
   return (
     <Scrollable
@@ -110,7 +113,11 @@ export const SymptomsHistory: FC<any> = ({navigation}) => {
                 </SingleRow>
                 <View style={styles.date}>
                   <Text style={text.default}>
-                    {format(new Date(Number(check.timestamp)), 'MMM dd')}
+                    {format(
+                      new Date(Number(check.timestamp)),
+                      'MMM dd',
+                      dateLocale
+                    )}
                   </Text>
                 </View>
               </View>

--- a/src/services/i18n/date.tsx
+++ b/src/services/i18n/date.tsx
@@ -1,0 +1,21 @@
+import {bn, enUS, es, ko, ru, zhCN} from 'date-fns/locale';
+
+const fallback = enUS;
+export const dateFnsLocales = {
+  bn,
+  en: enUS,
+  es,
+  ko,
+  ru,
+  zh: zhCN,
+  ht: fallback
+} as Record<string, any>;
+
+interface I18n {
+  language: string;
+}
+
+export const getDateLocaleOptions = (i18n: I18n) => {
+  const locale = dateFnsLocales[i18n.language] || fallback;
+  return {locale};
+};


### PR DESCRIPTION
https://github.com/project-vagabond/covid-green-app/issues/122#issuecomment-685998472 flagged that chart x axis labels are not translated.

There are a few other cases where we use `date-fns` to format dates, which I've also localised.

**Note: `date-fns` does not have localisation support for Haitian Creole (`ht`)** so I've had that fall back to English. If that's a problem we could get short and long form months translated and special case it (or maybe even contribute back to `date-fns` - it might be not much more work if the translator can provide us with everything). 