### PR TITLE
more a11y fixes

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -458,7 +458,9 @@
     "label": "New York State County you live in",
     "dropdownPlaceholder": "Choose your county",
     "searchPlaceholder": "Search",
+    "searchHint": "Search: showing autocomplete suggestions",
     "noResults": "No results found for this search.\nTry with something else.",
+    "noResultsHint": "Search: no results found for this search. Try with something else.",
     "notinny": "Not in New York State"
   },
   "appUsage": {

--- a/src/components/atoms/dropdown/basic.tsx
+++ b/src/components/atoms/dropdown/basic.tsx
@@ -1,6 +1,5 @@
-import React, {useState} from 'react';
+import React, {useState, forwardRef} from 'react';
 import {Text, View, TouchableWithoutFeedback, StyleSheet} from 'react-native';
-import {useTranslation} from 'react-i18next';
 
 import {BasicItem} from 'providers/settings';
 
@@ -29,88 +28,93 @@ export interface DropdownProps {
   instructions?: () => React.ReactNode;
 }
 
-export const Dropdown: React.FC<DropdownProps> = ({
-  label,
-  placeholder,
-  title,
-  items,
-  value,
-  onValueChange,
-  search,
-  itemRenderer,
-  display,
-  forceDisplay,
-  instructions
-}) => {
-  const {t} = useTranslation();
-  const [isModalVisible, setModalVisible] = useState(false);
+export const Dropdown = forwardRef<TouchableWithoutFeedback, DropdownProps>(
+  (
+    {
+      label,
+      placeholder,
+      title,
+      items,
+      value,
+      onValueChange,
+      search,
+      itemRenderer,
+      display,
+      forceDisplay,
+      instructions
+    },
+    ref
+  ) => {
+    const [isModalVisible, setModalVisible] = useState(false);
 
-  const onItemSelected = (newValue: string) => {
-    setModalVisible(false);
-    if (newValue !== value) {
-      onValueChange(newValue);
+    const onItemSelected = (newValue: string) => {
+      setModalVisible(false);
+      if (newValue !== value) {
+        onValueChange(newValue);
+      }
+    };
+
+    const selectedItem =
+      (value && items.find((i) => i.value === value)) || null;
+
+    let displayValue = placeholder;
+    let a11yValue = placeholder;
+    if (forceDisplay) {
+      displayValue = forceDisplay();
+      a11yValue = forceDisplay();
+    } else if (selectedItem) {
+      displayValue = (display && display(selectedItem)) || selectedItem.label;
+      a11yValue =
+        (display && display(selectedItem)) ||
+        selectedItem.hint ||
+        selectedItem.label;
     }
-  };
 
-  const selectedItem = (value && items.find((i) => i.value === value)) || null;
-
-  let displayValue = placeholder;
-  let a11yValue = placeholder;
-  if (forceDisplay) {
-    displayValue = forceDisplay();
-    a11yValue = forceDisplay();
-  } else if (selectedItem) {
-    displayValue = (display && display(selectedItem)) || selectedItem.label;
-    a11yValue =
-      (display && display(selectedItem)) ||
-      selectedItem.hint ||
-      selectedItem.label;
-  }
-
-  return (
-    <>
-      <TouchableWithoutFeedback
-        accessibilityRole="button"
-        accessibilityLabel={
-          value === '' ? label || '' : `${label || ''}, ${a11yValue}`
-        }
-        accessibilityHint={placeholder}
-        onPress={() => setModalVisible(true)}>
-        <View
+    return (
+      <>
+        <TouchableWithoutFeedback
+          ref={ref}
+          accessibilityRole="button"
+          accessibilityLabel={
+            value === '' ? label || '' : `${label || ''}, ${a11yValue}`
+          }
+          accessibilityHint={placeholder}
           hitSlop={{right: 40, bottom: 20, top: 20}}
-          style={styles.container}>
-          <View style={styles.content}>
-            {label && (
-              <>
-                <Text style={[text.default, {color: colors.text}]}>
-                  {label}
-                </Text>
-                <Spacing s={8} />
-              </>
-            )}
-            <Text numberOfLines={1} style={styles.displayValue}>
-              {displayValue}
-            </Text>
+          onPress={() => setModalVisible(true)}>
+          <View style={styles.container}>
+            <View style={styles.content}>
+              {label && (
+                <>
+                  <Text style={[text.default, {color: colors.text}]}>
+                    {label}
+                  </Text>
+                  <Spacing s={8} />
+                </>
+              )}
+              <Text numberOfLines={1} style={styles.displayValue}>
+                {displayValue}
+              </Text>
+            </View>
+            <AppIcons.ArrowRight width={18} height={18} color={colors.purple} />
           </View>
-          <AppIcons.ArrowRight width={18} height={18} color={colors.purple} />
-        </View>
-      </TouchableWithoutFeedback>
-      {isModalVisible && (
-        <DropdownModal
-          title={title || placeholder}
-          titleHint={label}
-          items={items}
-          selectedValue={value}
-          onSelect={onItemSelected}
-          onClose={() => setModalVisible(false)}
-          search={search}
-          itemRenderer={itemRenderer}
-          instructions={instructions}
-        />
-      )}
-    </>
-  );
-};
+        </TouchableWithoutFeedback>
+        {isModalVisible && (
+          <DropdownModal
+            title={title || placeholder}
+            titleHint={label}
+            items={items}
+            selectedValue={value}
+            onSelect={onItemSelected}
+            onClose={() => setModalVisible(false)}
+            search={search}
+            itemRenderer={itemRenderer}
+            instructions={instructions}
+          />
+        )}
+      </>
+    );
+  }
+);
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/atoms/dropdown/basic.tsx
+++ b/src/components/atoms/dropdown/basic.tsx
@@ -55,10 +55,16 @@ export const Dropdown: React.FC<DropdownProps> = ({
   const selectedItem = (value && items.find((i) => i.value === value)) || null;
 
   let displayValue = placeholder;
+  let a11yValue = placeholder;
   if (forceDisplay) {
     displayValue = forceDisplay();
+    a11yValue = forceDisplay();
   } else if (selectedItem) {
     displayValue = (display && display(selectedItem)) || selectedItem.label;
+    a11yValue =
+      (display && display(selectedItem)) ||
+      selectedItem.hint ||
+      selectedItem.label;
   }
 
   return (
@@ -66,7 +72,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       <TouchableWithoutFeedback
         accessibilityRole="button"
         accessibilityLabel={
-          value === '' ? label || '' : `${label || ''}::${displayValue}`
+          value === '' ? label || '' : `${label || ''}, ${a11yValue}`
         }
         accessibilityHint={placeholder}
         onPress={() => setModalVisible(true)}>
@@ -92,6 +98,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       {isModalVisible && (
         <DropdownModal
           title={title || placeholder}
+          titleHint={label}
           items={items}
           selectedValue={value}
           onSelect={onItemSelected}

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -23,8 +23,8 @@ import {text, colors} from 'theme';
 import {AppIcons} from 'assets/icons';
 
 interface DropdownModalProps extends Partial<ModalProps> {
-  close?: boolean;
   title: string;
+  titleHint?: string;
   items: BasicItem[];
   selectedValue: string;
   onSelect: (value: string) => void;
@@ -40,8 +40,8 @@ interface DropdownModalProps extends Partial<ModalProps> {
 }
 
 export const DropdownModal: React.FC<DropdownModalProps> = ({
-  close,
   title,
+  titleHint,
   items,
   selectedValue,
   onSelect,
@@ -66,6 +66,7 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
 
   const renderItem = (item: BasicItem, index: number) => {
     const {label, value, hint} = item;
+    const a11yLabel = hint || label;
     const color = value === selectedValue ? colors.purple : colors.text;
 
     if (!item.value) {
@@ -82,7 +83,9 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
     return (
       <TouchableWithoutFeedback
         accessibilityRole="radio"
-        accessibilityLabel={hint || label}
+        accessibilityLabel={
+          titleHint ? `${a11yLabel}, ${titleHint}` : a11yLabel
+        }
         accessibilityState={{selected: value === selectedValue}}
         key={`item_${index}`}
         onPress={() => onSelect(value)}>

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -120,7 +120,7 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
 
       if (search.term && !items.length) {
         return (
-          <View style={listStyles.contentWrapper}>
+          <View accessibilityElementsHidden style={listStyles.contentWrapper}>
             <Text style={listStyles.noResults}>{search?.noResults}</Text>
           </View>
         );
@@ -166,6 +166,12 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
             <View style={styles.search}>
               <TextInput
                 ref={searchInputRef}
+                accessibilityRole="search"
+                accessibilityLabel={
+                  search.term && !items.length
+                    ? t('county:noResultsHint')
+                    : t('county:searchHint')
+                }
                 style={[
                   styles.searchInput,
                   !!search.term && styles.searchUnderlined

--- a/src/components/atoms/select-list.tsx
+++ b/src/components/atoms/select-list.tsx
@@ -13,17 +13,19 @@ interface ListItem {
 }
 
 interface SelectListProps {
+  title?: string;
+  multiSelect?: boolean;
   items: ListItem[];
   selectedValue?: Value | Value[];
-  multiSelect?: boolean;
   onItemSelected: (value: any) => void;
 }
 
 export const SelectList: FC<SelectListProps> = ({
+  title,
+  multiSelect,
   items,
   selectedValue,
-  onItemSelected,
-  multiSelect
+  onItemSelected
 }) => {
   const hasSelectedValue = (value: Value) =>
     multiSelect && Array.isArray(selectedValue)
@@ -46,7 +48,7 @@ export const SelectList: FC<SelectListProps> = ({
       <TouchableWithoutFeedback
         key={`item-${index}`}
         onPress={() => onItemSelected(value)}
-        accessibilityLabel={label}
+        accessibilityLabel={title ? `${label}, ${title}` : label}
         accessibilityRole={multiSelect ? 'checkbox' : 'radio'}
         accessibilityState={{
           [multiSelect ? 'checked' : 'selected']: hasSelectedValue(value)

--- a/src/components/atoms/toast.tsx
+++ b/src/components/atoms/toast.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode} from 'react';
+import React, {ReactNode, forwardRef} from 'react';
 import {StyleSheet, View, ViewStyle, Text, TextStyle} from 'react-native';
 
 import {Markdown} from './markdown';
@@ -18,45 +18,51 @@ interface ToastProps {
   textStyle?: TextStyle;
 }
 
-const Toast: React.FC<ToastProps> = ({
-  type,
-  color,
-  icon,
-  message,
-  style,
-  children,
-  iconStyle = {},
-  textStyle = {}
-}) => {
-  let iconStyling: ViewStyle[] = [styles.icon, iconStyle];
-  let textStyling: TextStyle[] = [text.defaultBold, textStyle];
+const Toast = forwardRef<View, ToastProps>(
+  (
+    {
+      type,
+      color,
+      icon,
+      message,
+      style,
+      children,
+      iconStyle = {},
+      textStyle = {}
+    },
+    ref
+  ) => {
+    let iconStyling: ViewStyle[] = [styles.icon, iconStyle];
+    let textStyling: TextStyle[] = [text.defaultBold, textStyle];
 
-  if (type === 'error') {
-    iconStyling.push(styles.iconError);
-    textStyling.push(styles.messageError);
-  }
+    if (type === 'error') {
+      iconStyling.push(styles.iconError);
+      textStyling.push(styles.messageError);
+    }
 
-  if (color) {
-    iconStyling.push({backgroundColor: color});
-  }
+    if (color) {
+      iconStyling.push({backgroundColor: color});
+    }
 
-  return (
-    <View
-      accessibilityRole="alert"
-      accessibilityLiveRegion="assertive"
-      style={[
-        styles.container,
-        style,
-        type === 'error' && styles.containerError
-      ]}>
-      {icon && <View style={iconStyling}>{icon}</View>}
-      <View style={styles.messageContainer}>
-        {message && <Text style={textStyling}>{message}</Text>}
-        {children && <Markdown>{children}</Markdown>}
+    return (
+      <View
+        ref={ref}
+        accessibilityRole="alert"
+        accessibilityLiveRegion="assertive"
+        style={[
+          styles.container,
+          style,
+          type === 'error' && styles.containerError
+        ]}>
+        {icon && <View style={iconStyling}>{icon}</View>}
+        <View style={styles.messageContainer}>
+          {message && <Text style={textStyling}>{message}</Text>}
+          {children && <Markdown>{children}</Markdown>}
+        </View>
       </View>
-    </View>
-  );
-};
+    );
+  }
+);
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/views/settings/check-in.tsx
+++ b/src/components/views/settings/check-in.tsx
@@ -1,9 +1,10 @@
-import React, {useState, useRef} from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 import {Text, ScrollView} from 'react-native';
 import {useTranslation} from 'react-i18next';
 
 import {useApplication} from 'providers/context';
 import {useDbText} from 'providers/settings';
+import {setAccessibilityFocusRef, useFocusRef} from 'hooks/accessibility';
 import {useSymptomChecker} from 'hooks/symptom-checker';
 
 import {Spacing, Separator} from 'components/atoms/layout';
@@ -40,6 +41,12 @@ export const CheckInSettings: React.FC<CheckInSettingsProps> = ({
     countiesOptions
   } = useDbText();
   const app = useApplication();
+  const [toastRef, ref1, ref2, ref3, ref4, ref5] = useFocusRef(
+    {
+      accessibilityRefocus: false
+    },
+    6
+  );
   const {getNextScreen} = useSymptomChecker();
 
   const scrollViewRef = useRef<ScrollView>(null);
@@ -61,6 +68,12 @@ export const CheckInSettings: React.FC<CheckInSettingsProps> = ({
     saved: false
   });
   const [searchTerm, setSearchTerm] = useState<string>('');
+
+  useEffect(() => {
+    if (profile.saved) {
+      setTimeout(() => setAccessibilityFocusRef(toastRef), 250);
+    }
+  }, [toastRef, profile.saved]);
 
   const counties = !searchTerm
     ? countiesOptions
@@ -100,6 +113,7 @@ export const CheckInSettings: React.FC<CheckInSettingsProps> = ({
 
   const successToast = profile.saved && (
     <Toast
+      ref={toastRef}
       type="success"
       icon={<AppIcons.Success width={24} height={24} color={colors.success} />}
       message={t('common:changesUpdated')}
@@ -108,6 +122,7 @@ export const CheckInSettings: React.FC<CheckInSettingsProps> = ({
 
   return (
     <Scrollable
+      accessibilityRefocus={false}
       toast={successToast}
       heading={t('checkInSettings:title')}
       scrollViewRef={scrollViewRef}>
@@ -115,6 +130,7 @@ export const CheckInSettings: React.FC<CheckInSettingsProps> = ({
       <Spacing s={16} />
       <Card>
         <Dropdown
+          ref={ref1}
           label={t('county:label')}
           placeholder={t('county:dropdownPlaceholder')}
           items={counties}
@@ -125,49 +141,58 @@ export const CheckInSettings: React.FC<CheckInSettingsProps> = ({
             onChange: setSearchTerm,
             noResults: t('county:noResults')
           }}
-          onValueChange={(value) =>
-            setProfile({...profile, saved: false, county: value})
-          }
+          onValueChange={(value) => {
+            setProfile({...profile, saved: false, county: value});
+            setAccessibilityFocusRef(ref1);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref2}
           label={t('gender:label')}
           placeholder={t('gender:placeholder')}
           items={genderOptions}
           value={profile.gender}
-          onValueChange={(value) =>
-            setProfile({...profile, saved: false, gender: value})
-          }
+          onValueChange={(value) => {
+            setProfile({...profile, saved: false, gender: value});
+            setAccessibilityFocusRef(ref2);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref3}
           label={t('ageRange:label')}
           placeholder={t('ageRange:placeholder')}
           items={ageRangeOptions}
           value={profile.ageRange}
-          onValueChange={(value) =>
-            setProfile({...profile, saved: false, ageRange: value})
-          }
+          onValueChange={(value) => {
+            setProfile({...profile, saved: false, ageRange: value});
+            setAccessibilityFocusRef(ref3);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref4}
           label={t('race:label')}
           placeholder={t('race:placeholder')}
           items={raceOptions}
           value={profile.race}
-          onValueChange={(value) =>
-            setProfile({...profile, saved: false, race: value})
-          }
+          onValueChange={(value) => {
+            setProfile({...profile, saved: false, race: value});
+            setAccessibilityFocusRef(ref4);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref5}
           label={t('ethnicity:label')}
           placeholder={t('ethnicity:placeholder')}
           items={ethnicityOptions}
           value={profile.ethnicity}
-          onValueChange={(value) =>
-            setProfile({...profile, saved: false, ethnicity: value})
-          }
+          onValueChange={(value) => {
+            setProfile({...profile, saved: false, ethnicity: value});
+            setAccessibilityFocusRef(ref5);
+          }}
         />
         <Spacing s={24} />
         <Button

--- a/src/components/views/settings/contact-tracing.tsx
+++ b/src/components/views/settings/contact-tracing.tsx
@@ -1,5 +1,5 @@
-import React, {useState, useRef} from 'react';
-import {Platform, ScrollView, Text, Linking, Alert} from 'react-native';
+import React, {FC} from 'react';
+import {Platform, Text, Linking, Alert} from 'react-native';
 import * as IntentLauncher from 'expo-intent-launcher';
 import {
   useExposure,
@@ -11,13 +11,11 @@ import {useTranslation} from 'react-i18next';
 import {Button} from 'components/atoms/button';
 import {Markdown} from 'components/atoms/markdown';
 import {Spacing, Separator} from 'components/atoms/layout';
-import {Toast} from 'components/atoms/toast';
 import {KeyboardScrollable} from 'components/templates/keyboard-scrollable';
 
 import {colors, text} from 'theme';
-import {AppIcons} from 'assets/icons';
 
-export const ContactTracingSettings = () => {
+export const ContactTracingSettings: FC = () => {
   const {t} = useTranslation();
   const {
     canSupport,
@@ -29,9 +27,6 @@ export const ContactTracingSettings = () => {
     deleteExposureData,
     askPermissions
   } = useExposure();
-
-  const [confirmedChanges] = useState<boolean>(false);
-  const scrollViewRef = useRef<ScrollView>(null);
 
   const gotoSettings = async () => {
     try {
@@ -73,25 +68,13 @@ export const ContactTracingSettings = () => {
     );
   };
 
-  const successToast = confirmedChanges && (
-    <Toast
-      color="rgba(0, 207, 104, 0.16)"
-      message={t('common:changesUpdated')}
-      type="success"
-      icon={<AppIcons.Success width={24} height={24} color={colors.success} />}
-    />
-  );
-
   const isServiceActive = status.state === StatusState.active && enabled;
   const ensNotAuthorised =
     !isServiceActive &&
     (Platform.OS === 'android' || isAuthorised === AuthorisedStatus.unknown);
 
   return (
-    <KeyboardScrollable
-      toast={successToast}
-      heading={t('myCovidAlerts:title')}
-      scrollViewRef={scrollViewRef}>
+    <KeyboardScrollable heading={t('myCovidAlerts:title')}>
       <Text style={text.defaultBold}>{t('settings:status:title')}</Text>
       <Spacing s={12} />
       <Text style={text.largeBold}>

--- a/src/components/views/settings/language.tsx
+++ b/src/components/views/settings/language.tsx
@@ -29,11 +29,12 @@ export const Language = () => {
 
   return (
     <Scrollable heading={t('languageSettings:title')}>
-      <View>
+      <View accessibilityElementsHidden>
         <Markdown>{t('languageSettings:intro')}</Markdown>
       </View>
       <Spacing s={20} />
       <SelectList
+        title={t('languageSettings:intro')}
         items={languages}
         selectedValue={currentLanguage!.value}
         onItemSelected={(lang) => {

--- a/src/components/views/symptom-checker/intro.tsx
+++ b/src/components/views/symptom-checker/intro.tsx
@@ -5,6 +5,7 @@ import {useNavigation} from '@react-navigation/native';
 
 import {useApplication} from 'providers/context';
 import {useDbText} from 'providers/settings';
+import {useFocusRef, setAccessibilityFocusRef} from 'hooks/accessibility';
 import {useSymptomChecker} from 'hooks/symptom-checker';
 
 import {Spacing, Separator} from 'components/atoms/layout';
@@ -35,6 +36,12 @@ export function CheckInIntro() {
     countiesOptions
   } = useDbText();
   const {getNextScreen} = useSymptomChecker();
+  const [ref1, ref2, ref3, ref4, ref5] = useFocusRef(
+    {
+      accessibilityRefocus: false
+    },
+    5
+  );
 
   const [state, setState] = useState<IntroState>({
     gender: (app.user && app.user.gender) || '',
@@ -102,6 +109,7 @@ export function CheckInIntro() {
         <Text style={text.default}>{t('checker:introOptional')}</Text>
         <Spacing s={24} />
         <Dropdown
+          ref={ref1}
           label={t('county:label')}
           placeholder={t('county:dropdownPlaceholder')}
           items={counties}
@@ -112,39 +120,58 @@ export function CheckInIntro() {
             onChange: setSearchTerm,
             noResults: t('county:noResults')
           }}
-          onValueChange={(county) => setState((s) => ({...s, county}))}
+          onValueChange={(county) => {
+            setState((s) => ({...s, county}));
+            setAccessibilityFocusRef(ref1);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref2}
           label={t('gender:label')}
           placeholder={t('gender:placeholder')}
           items={genderOptions}
           value={state.gender}
-          onValueChange={(gender) => setState((s) => ({...s, gender}))}
+          onValueChange={(gender) => {
+            setState((s) => ({...s, gender}));
+            setAccessibilityFocusRef(ref2);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref3}
           label={t('ageRange:label')}
           placeholder={t('ageRange:placeholder')}
           items={ageRangeOptions}
           value={state.ageRange}
-          onValueChange={(ageRange) => setState((s) => ({...s, ageRange}))}
+          onValueChange={(ageRange) => {
+            setState((s) => ({...s, ageRange}));
+            setAccessibilityFocusRef(ref3);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref4}
           label={t('race:label')}
           placeholder={t('race:placeholder')}
           items={raceOptions}
           value={state.race}
-          onValueChange={(race) => setState((s) => ({...s, race}))}
+          onValueChange={(race) => {
+            setState((s) => ({...s, race}));
+            setAccessibilityFocusRef(ref4);
+          }}
         />
         <Separator />
         <Dropdown
+          ref={ref5}
           label={t('ethnicity:label')}
           placeholder={t('ethnicity:placeholder')}
           items={ethnicityOptions}
           value={state.ethnicity}
-          onValueChange={(ethnicity) => setState((s) => ({...s, ethnicity}))}
+          onValueChange={(ethnicity) => {
+            setState((s) => ({...s, ethnicity}));
+            setAccessibilityFocusRef(ref5);
+          }}
         />
         <Separator />
         <Button width="100%" onPress={onContinue}>

--- a/src/components/views/symptom-checker/symptoms.tsx
+++ b/src/components/views/symptom-checker/symptoms.tsx
@@ -111,9 +111,9 @@ export const CheckInSymptoms = () => {
       backgroundColor={colors.background}
       heading={t('checker:title')}>
       <Card>
-        <Text style={text.largeBold}>{`${t(
-          'checker:symptoms:subtitle'
-        )}`}</Text>
+        <Text accessibilityElementsHidden style={text.largeBold}>
+          {t('checker:symptoms:subtitle')}
+        </Text>
         <Spacing s={36} />
         <Button
           width="100%"
@@ -124,9 +124,10 @@ export const CheckInSymptoms = () => {
         </Button>
         <Spacing s={36} />
         <SelectList
+          title={t('checker:symptoms:subtitle')}
+          multiSelect={true}
           items={items}
           selectedValue={selectedValue}
-          multiSelect={true}
           onItemSelected={handleItemSelected}
         />
         <Spacing s={36} />


### PR DESCRIPTION
- Checkboxes/radio buttons should include the group label (e.g. Age range) in the label for each item
- If there is a hint for an item use that instead of the label
- when opening modals, focus back on the element that trigger it to open - did it "manually" for profile. We could find an more generic solution, but maybe not worth the time.
