### PR TITLE
Accessibility for Markdown links

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -550,10 +550,5 @@
     "title": "Notifications are disabled",
     "text": "You need to allow notifications so you can receive COVID alerts. We will only contact you in case of a Close Contact.",
     "gotoSettings": "Go to App Settings"
-  },
-  "markdown": {
-    "http": "Open web page",
-    "tel": "Call telephone number",
-    "navigate": "Go to app screen"
   }
 }

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -550,5 +550,10 @@
     "title": "Notifications are disabled",
     "text": "You need to allow notifications so you can receive COVID alerts. We will only contact you in case of a Close Contact.",
     "gotoSettings": "Go to App Settings"
+  },
+  "markdown": {
+    "http": "Open web page",
+    "tel": "Call telephone number",
+    "navigate": "Go to app screen"
   }
 }

--- a/src/components/atoms/link.tsx
+++ b/src/components/atoms/link.tsx
@@ -11,6 +11,7 @@ import {text as textStyles, colors} from 'theme';
 
 interface LinkProps {
   a11yRole?: 'link' | 'button';
+  a11yHint?: string;
   style?: ViewStyle;
   Icon?: ReactNode;
   text?: string;
@@ -24,6 +25,7 @@ export const Link: React.FC<LinkProps> = React.forwardRef(
   (
     {
       a11yRole = 'button',
+      a11yHint,
       style,
       Icon,
       text,
@@ -41,6 +43,7 @@ export const Link: React.FC<LinkProps> = React.forwardRef(
         <TouchableWithoutFeedback
           ref={ref}
           accessibilityRole={a11yRole}
+          accessibilityHint={a11yHint}
           onPress={onPress}>
           <Text
             onPress={() => onPress}

--- a/src/components/atoms/markdown.tsx
+++ b/src/components/atoms/markdown.tsx
@@ -115,6 +115,7 @@ export const Markdown: React.FC<Markdown> = ({
     // Re-check state on app refocus to catch changes to device settings
     AppState.addEventListener('change', checkScreenReader);
     return () => AppState.removeEventListener('change', checkScreenReader);
+      checkScreenReader();
   }, []);
 
   const defaultRenderLink: RenderLink = (href, title, children, key) =>

--- a/src/components/atoms/markdown.tsx
+++ b/src/components/atoms/markdown.tsx
@@ -91,6 +91,7 @@ const MarkdownLink = (
       key={key}
       onPress={() => navigation.navigate(href)}
       a11yHint={title}
+      a11yRole="button">
       {children}
     </Link>
   );

--- a/src/components/atoms/markdown.tsx
+++ b/src/components/atoms/markdown.tsx
@@ -5,7 +5,8 @@ import {
   Linking,
   AccessibilityInfo,
   TouchableWithoutFeedback,
-  AppState
+  AppState,
+  Platform
 } from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import * as WebBrowser from 'expo-web-browser';
@@ -45,7 +46,7 @@ const MarkdownLink = (
   children: any,
   key: string,
   navigation: any,
-  screenReaderEnabled: boolean
+  androidScreenReaderEnabled: boolean
 ) => {
   const isHttp = href.startsWith('http');
   const isTel = href.startsWith('tel');
@@ -65,7 +66,7 @@ const MarkdownLink = (
           });
         };
 
-    return screenReaderEnabled ? (
+    return androidScreenReaderEnabled ? (
       <TouchableWithoutFeedback
         accessibilityRole="link"
         accessibilityHint={title}
@@ -105,21 +106,32 @@ export const Markdown: React.FC<Markdown> = ({
 }) => {
   const navigation = useNavigation();
 
-  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
+  const [androidScreenReaderEnabled, setAndroidScreenReaderEnabled] = useState(
+    false
+  );
 
   useEffect(() => {
-    const checkScreenReader = () =>
-      AccessibilityInfo.isScreenReaderEnabled().then((enabled) =>
-        setScreenReaderEnabled(enabled)
-      );
-    // Re-check state on app refocus to catch changes to device settings
-    AppState.addEventListener('change', checkScreenReader);
-    return () => AppState.removeEventListener('change', checkScreenReader);
+    if (Platform.OS === 'android') {
+      const checkScreenReader = () =>
+        AccessibilityInfo.isScreenReaderEnabled().then((enabled) =>
+          setAndroidScreenReaderEnabled(enabled)
+        );
+      // Re-check state on app refocus to catch changes to device settings
+      AppState.addEventListener('change', checkScreenReader);
       checkScreenReader();
+      return () => AppState.removeEventListener('change', checkScreenReader);
+    }
   }, []);
 
   const defaultRenderLink: RenderLink = (href, title, children, key) =>
-    MarkdownLink(href, title, children, key, navigation, screenReaderEnabled);
+    MarkdownLink(
+      href,
+      title,
+      children,
+      key,
+      navigation,
+      androidScreenReaderEnabled
+    );
 
   const combinedStyles = {
     ...defaultMarkdownStylesheet,

--- a/src/components/atoms/markdown.tsx
+++ b/src/components/atoms/markdown.tsx
@@ -45,8 +45,7 @@ const MarkdownLink = (
   title: string,
   children: any,
   key: string,
-  navigation: any,
-  t: TFunction
+  navigation: any
 ) => {
   const hasScreenReader = AccessibilityInfo.isScreenReaderEnabled();
 
@@ -56,7 +55,6 @@ const MarkdownLink = (
   // Markdown titles like [text](http://site.com "Title here") will be override default accessibility labels
 
   if (isHttp || isTel) {
-    const linkHint = title || (isTel ? t('markdown:tel') : t('markdown:http'));
     const handle = isTel
       ? () => {
           const crossPlatformTarget = href.replace(/:(?=\d|\+)/, '://');
@@ -72,7 +70,7 @@ const MarkdownLink = (
     return hasScreenReader ? (
       <TouchableWithoutFeedback
         accessibilityRole="link"
-        accessibilityHint={linkHint}
+        accessibilityHint={title}
         accessibilityLabel={childrenAsText(children)}
         onPress={handle}>
         <Text>{children}</Text>
@@ -81,19 +79,18 @@ const MarkdownLink = (
       <Text
         accessible={true}
         accessibilityRole="link"
-        accessibilityHint={linkHint}
+        accessibilityHint={title}
         onPress={handle}>
         {children}
       </Text>
     );
   }
 
-  const navHint = title || t('markdown:navigate');
   return (
     <Link
       key={key}
       onPress={() => navigation.navigate(href)}
-      a11yHint={navHint}>
+      a11yHint={title}
       {children}
     </Link>
   );
@@ -108,10 +105,9 @@ export const Markdown: React.FC<Markdown> = ({
   children: C
 }) => {
   const navigation = useNavigation();
-  const {t} = useTranslation();
 
   const defaultRenderLink: RenderLink = (href, title, children, key) =>
-    MarkdownLink(href, title, children, key, navigation, t);
+    MarkdownLink(href, title, children, key, navigation);
 
   const combinedStyles = {
     ...defaultMarkdownStylesheet,

--- a/src/components/atoms/markdown.tsx
+++ b/src/components/atoms/markdown.tsx
@@ -68,6 +68,7 @@ const MarkdownLink = (
 
     return androidScreenReaderEnabled ? (
       <TouchableWithoutFeedback
+        key={key}
         accessibilityRole="link"
         accessibilityHint={title}
         accessibilityLabel={childrenAsText(children)}
@@ -76,6 +77,7 @@ const MarkdownLink = (
       </TouchableWithoutFeedback>
     ) : (
       <Text
+        key={key}
         accessible={true}
         accessibilityRole="link"
         accessibilityHint={title}

--- a/src/theme/markdown-styles.ts
+++ b/src/theme/markdown-styles.ts
@@ -12,10 +12,10 @@ export default (text: Styles): Styles => ({
   text: {
     ...text.default,
     flexWrap: 'wrap',
-    marginBottom: 8
+    margin: 0
   },
   block: {
-    marginBottom: 8
+    marginBottom: 16
   },
   link: {
     ...text.defaultBoldBlue


### PR DESCRIPTION
Tested on Android, not yet on iOS. 

On Android this:

 - Splits the link out into a focus-able section if it's in a block of text and the screen reader is active
 - Has the screen reader read the text of the link first, then a hint which is either the `title` from Markdown if there is one or a translated default if there isn't (e.g. "Open web page", "Call telephone number"), then the role, "link".

So typical UX is like:

> 1-202-002-200; call telephone number; link

> Find sites in your area; open web page; link

Those are translatable defaults; specific hints for accessibility can be specified in Markdown if needed case-by-case like `[text](http://site.com "This is the title")`, for example this is possible:

> Find sites in your area; open website listing testing sites by NY locality; link 

@floridemai can you point me towards issues relating to markdown accessibility so I can see what other features we need?