### PR TITLE
(WIP) Use react-native-accessible-selectable for checkboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react": "16.13.1",
     "react-i18next": "^11.7.0",
     "react-native": "0.63.2",
+    "react-native-accessible-selectable": "^0.1.0",
     "react-native-device-info": "^5.6.5",
     "react-native-dotenv": "^2.3.0",
     "react-native-easy-markdown": "^2.0.0",

--- a/src/components/atoms/select-list.tsx
+++ b/src/components/atoms/select-list.tsx
@@ -1,9 +1,12 @@
 import React, {FC} from 'react';
 import {StyleSheet, TouchableWithoutFeedback, View, Text} from 'react-native';
+import {makeSelectable} from 'react-native-accessible-selectable';
 
 import {text, colors} from 'theme';
 
 import Icons from 'assets/icons';
+
+const AccessibleCheckbox = makeSelectable(TouchableWithoutFeedback);
 
 type Value = string | number; // May be used as object keys
 
@@ -45,11 +48,12 @@ export const SelectList: FC<SelectListProps> = ({
       Icons[multiSelect ? 'CheckMarkMultiSelect' : 'CheckMark'];
 
     return (
-      <TouchableWithoutFeedback
+      <AccessibleCheckbox
         key={`item-${index}`}
         onPress={() => onItemSelected(value)}
         accessibilityLabel={title ? `${label}, ${title}` : label}
         accessibilityRole={multiSelect ? 'checkbox' : 'radio'}
+        accessibilityLiveRegion="assertive"
         accessibilityState={{
           [multiSelect ? 'checked' : 'selected']: hasSelectedValue(value)
         }}>
@@ -66,7 +70,7 @@ export const SelectList: FC<SelectListProps> = ({
             <Text style={[text.defaultBold, {color}]}>{label}</Text>
           </View>
         </View>
-      </TouchableWithoutFeedback>
+      </AccessibleCheckbox>
     );
   };
 

--- a/src/components/views/symptom-checker/symptoms.tsx
+++ b/src/components/views/symptom-checker/symptoms.tsx
@@ -78,8 +78,8 @@ export const CheckInSymptoms = () => {
   const handleItemSelected = async (symptom: Symptom) => {
     const newValue = Number(!values[symptom]);
     setFieldValue(symptom, newValue, false);
-
     setSymptoms((s) => ({...s, [symptom]: newValue}));
+
     await app.setContext({
       checkerSymptoms: {
         ...app.checkerSymptoms,

--- a/src/components/views/symptom-checker/symptoms.tsx
+++ b/src/components/views/symptom-checker/symptoms.tsx
@@ -78,8 +78,8 @@ export const CheckInSymptoms = () => {
   const handleItemSelected = async (symptom: Symptom) => {
     const newValue = Number(!values[symptom]);
     setFieldValue(symptom, newValue, false);
-    setSymptoms((s) => ({...s, [symptom]: newValue}));
 
+    setSymptoms((s) => ({...s, [symptom]: newValue}));
     await app.setContext({
       checkerSymptoms: {
         ...app.checkerSymptoms,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6659,6 +6659,11 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-native-accessible-selectable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-accessible-selectable/-/react-native-accessible-selectable-0.1.0.tgz#0c779a79a5d2d74afdc9cd166afb6dafd5f06095"
+  integrity sha512-4QVmy760R1QsZSneoUlOgwhFpYgoVbAELavNbRF8OZ/TCA6Rwhn29F4g9IPro4ZfTUvR9AXKMlBebWHH7oNevQ==
+
 react-native-animatable@1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"


### PR DESCRIPTION
**This adds iOS native dependencies so:**

 - do cocoa pods install
 - check the iOS build still works as expected

For the issue described in this comment: https://github.com/project-vagabond/covid-green-app/issues/245#issuecomment-687514574

Without this, React state update re-render timings cause the old `accessibilityState` to be read before the new one on checking a checkbox: "Not chec... Checked" or "Chec... Not checked". 

This adds a dependency designed for exactly this problem that does some platform specific direct internal state updates to just say the new state.