### PR TITLE
change styling of alert tab item in warning mode

### DIFF
--- a/src/components/organisms/tab-bar-bottom.tsx
+++ b/src/components/organisms/tab-bar-bottom.tsx
@@ -58,14 +58,7 @@ const ctOffSelected = (
   />
 );
 
-const ctAlertUnselected = (
-  <TabBarIcons.ContactTracing.Alert
-    width={32}
-    height={24}
-    color={colors.darkGray}
-  />
-);
-const ctAlertSelected = (
+const ctAlert = (
   <TabBarIcons.ContactTracing.Alert
     width={32}
     height={24}
@@ -116,12 +109,12 @@ export const TabBarBottom: FC<any> = ({navigation, state}) => {
       label: t('tabBar:contactTracing'),
       icon: {
         inactive: hasAlerts
-          ? ctAlertUnselected
+          ? ctAlert
           : status.state === StatusState.active && enabled
           ? ctOnUnselected
           : ctOffUnselected,
         active: hasAlerts
-          ? ctAlertSelected
+          ? ctAlert
           : status.state === StatusState.active && enabled
           ? ctOnSelected
           : ctOffSelected
@@ -149,6 +142,7 @@ export const TabBarBottom: FC<any> = ({navigation, state}) => {
       <View accessibilityRole="tablist" style={styles.tabBar}>
         {tabItems.map((tab, index) => {
           const isActive = state.index === index;
+          const isAlertsActive = isActive && index === 2 && hasAlerts;
           const routeName = state.routes[index] && state.routes[index].name;
           const hint = [`${index + 1} of ${tabItems.length}`, tab.hint].join(
             ','
@@ -162,11 +156,20 @@ export const TabBarBottom: FC<any> = ({navigation, state}) => {
               accessibilityHint={hint}
               accessibilityState={{selected: isActive}}
               onPress={() => navigation.navigate(routeName)}>
-              <View style={[styles.tab, isActive ? styles.highlighted : {}]}>
+              <View
+                style={[
+                  styles.tab,
+                  isActive ? styles.highlighted : {},
+                  isAlertsActive && styles.alertsActive
+                ]}>
                 {getIcon(tab, isActive, status.state)}
                 <Text
                   allowFontScaling={false}
-                  style={[styles.label, isActive && styles.labelActive]}>
+                  style={[
+                    styles.label,
+                    isActive && styles.labelActive,
+                    isAlertsActive && styles.warningText
+                  ]}>
                   {tab.label}
                 </Text>
               </View>
@@ -214,5 +217,12 @@ const styles = StyleSheet.create({
   highlighted: {
     backgroundColor: colors.tabs.highlighted,
     borderColor: colors.purple
+  },
+  alertsActive: {
+    backgroundColor: colors.tabs.alertsHighlighted,
+    borderColor: colors.warning
+  },
+  warningText: {
+    color: colors.warningText
   }
 });

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -21,7 +21,8 @@ export const colors = {
     gray: '#b2b2b2'
   },
   tabs: {
-    highlighted: '#e7e8f2'
+    highlighted: '#e7e8f2',
+    alertsHighlighted: '#ffefef'
   },
   info: {
     primary: info,
@@ -47,6 +48,7 @@ export const colors = {
   selectedDot: '#2E2E2E',
   success: '#00CF68', // only 1 usage?
   text: '#2E2E2E',
+  warningText: '#4b0600',
   warning: '#DC0000',
   buttons: {
     default: {


### PR DESCRIPTION
changes requested by Antoine

[ref](https://github.com/project-vagabond/covid-green-app/issues/326)

![Screenshot_20200909_130051_gov ny health proximity](https://user-images.githubusercontent.com/1004239/92584902-e8a26c00-f29c-11ea-8259-193abe9eac1d.jpg)
![Screenshot_20200909_130056_gov ny health proximity](https://user-images.githubusercontent.com/1004239/92584912-eb04c600-f29c-11ea-8bf8-ca2259700398.jpg)

](url)