### PR TITLE
Make charts more resilient to bad or unexpected data 

### DIFF
--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -10,7 +10,7 @@ import {ChartData, AxisData} from 'components/organisms/tracker-charts';
 interface BarChartContentProps {
   chartData: ChartData;
   axisData: AxisData;
-  averagesData?: ChartData;
+  averagesData: ChartData;
   contentInset: {top: number; bottom: number};
   rollingAverage?: number;
   days?: number;
@@ -95,9 +95,9 @@ export const BarChartContent: FC<BarChartContentProps> = ({
 
   const TrendLine: FC<TrendLineProps> = (props) => {
     const {x, y, bandwidth, lineWidth, color} = props;
-    const rollingData =
-      averagesData ||
-      calculateRollingAverages(rollingAverage, visibleChartData, chartData);
+    const rollingData = rollingAverage
+      ? calculateRollingAverages(rollingAverage, visibleChartData, chartData)
+      : averagesData;
 
     const lineGenerator = line();
     lineGenerator.curve(curveMonotoneX);

--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -103,7 +103,7 @@ export const BarChartContent: FC<BarChartContentProps> = ({
     lineGenerator.curve(curveMonotoneX);
     const pathDef = lineGenerator(
       rollingData.map((value, index) => [
-        x(index) || 0 + bandwidth / 2,
+        (x(index) || 0) + bandwidth / 2,
         y(value) || 0
       ])
     );

--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -101,10 +101,9 @@ export const BarChartContent: FC<BarChartContentProps> = ({
 
   const TrendLine: FC<TrendLineProps> = (props) => {
     const {x, y, bandwidth, lineWidth, color} = props;
-    const rollingData =
-      1 && rollingAverage
-        ? calculateRollingAverages(rollingAverage, chartData, days)
-        : averagesData.slice(startPoint);
+    const rollingData = rollingAverage
+      ? calculateRollingAverages(rollingAverage, chartData, days)
+      : averagesData.slice(startPoint);
 
     const lineGenerator = line();
     lineGenerator.curve(curveMonotoneX);

--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -51,7 +51,6 @@ const calculateRollingAverages = (
       ? chartData.map((_, index) => {
           const avStart = Math.max(0, index - rollingOffset);
           const avEnd = index + 1;
-          console.log(index, avStart, avEnd);
           const avValues = chartData.slice(avStart, avEnd);
           const total = avValues.reduce((sum, num) => sum + num, 0);
           return total / avValues.length;

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -5,7 +5,7 @@ import {YAxis, XAxis} from 'react-native-svg-charts';
 import {useTranslation} from 'react-i18next';
 import {format} from 'date-fns';
 
-import {dateFnsLocales, getDateLocaleOptions} from 'services/i18n/date';
+import {getDateLocaleOptions} from 'services/i18n/date';
 import {text, colors} from 'theme';
 import {BarChartContent} from 'components/atoms/bar-chart-content';
 import {Spacing} from 'components/atoms/spacing';
@@ -17,11 +17,9 @@ interface TrackerBarChartProps {
   description?: string;
   chartData: ChartData;
   axisData: AxisData;
-  days?: number;
   yMin?: number;
   ySuffix?: string;
   averagesData: ChartData;
-  rollingAverage?: number;
   intervalsCount?: number;
   backgroundColor?: string;
   primaryColor?: string;
@@ -55,8 +53,6 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   axisData,
   averagesData,
   description,
-  rollingAverage,
-  days = 30,
   yMin = 5,
   ySuffix = '',
   primaryColor = '#CD4000',
@@ -67,7 +63,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   const dateLocale = getDateLocaleOptions(i18n);
   const wideMonthLocales = ['bn'];
 
-  const daysLimit = Math.min(days, chartData.length);
+  const daysLimit = Math.min(axisData.length, chartData.length);
 
   // Arbitrary while data source is unstable, pending chart redesign
   const intervalsCount = daysLimit < 30 ? 7 : 6;
@@ -115,7 +111,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   const maxValue = chartData.reduce((max, value) => Math.max(max, value), 0);
   const yMax = maxValue < yMin ? yMin : undefined;
 
-  const showLegend = !!(rollingAverage || averagesData.length);
+  const showLegend = !!averagesData.length;
 
   const formatXAxisMonthLabel = (_: any, index: number) => {
     if (isAxisLabelHidden(index)) {
@@ -182,7 +178,6 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
           <BarChartContent
             chartData={chartData}
             averagesData={averagesData}
-            days={daysLimit}
             cornerRoundness={2}
             scale={scaleBand}
             contentInset={contentInset}
@@ -190,7 +185,6 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
             primaryColor={primaryColor}
             secondaryColor={secondaryColor}
             backgroundColor={backgroundColor}
-            rollingAverage={rollingAverage}
             yMax={yMax}
           />
           <XAxis

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -63,9 +63,9 @@ function roundNumber(num: number, places: number = 2) {
 
 export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   title,
-  chartData,
-  axisData,
-  averagesData,
+  chartData: rawChartData,
+  axisData: rawAxisData,
+  averagesData: rawAveragesData = [],
   description,
   rollingAverage = 0,
   days = 30,
@@ -78,13 +78,13 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   const {t, i18n} = useTranslation();
   const dateLocale = getDateLocaleOptions(i18n);
   const wideMonthLocales = ['bn'];
-  const intervalsCount = axisData.length < 30 ? 7 : 6;
 
-  const daysLimit = Math.min(days, chartData.length);
+  const daysLimit = Math.min(days, rawChartData.length);
+  const intervalsCount = daysLimit < 30 ? 7 : 6;
 
-  chartData = trimData(chartData, daysLimit, rollingAverage);
-  averagesData = trimData(averagesData || [], daysLimit, rollingAverage);
-  axisData = trimAxisData(axisData, daysLimit);
+  const chartData = trimData(rawChartData, daysLimit, rollingAverage);
+  const averagesData = trimData(rawAveragesData, daysLimit, rollingAverage);
+  const axisData = trimAxisData(rawAxisData, daysLimit);
 
   if (!chartData.length || !axisData.length) {
     return null;

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -194,14 +194,14 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
             yMax={yMax}
           />
           <XAxis
-            data={chartData}
+            data={Array(daysLimit).fill(1)}
             contentInset={contentInset}
             scale={scaleBand}
             svg={{...xAxisSvg, y: 3}}
             formatLabel={formatXAxisDayLabel}
           />
           <XAxis
-            data={chartData}
+            data={Array(daysLimit).fill(1)}
             contentInset={contentInset}
             scale={scaleBand}
             svg={xAxisSvg}

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -20,7 +20,7 @@ interface TrackerBarChartProps {
   days?: number;
   yMin?: number;
   ySuffix?: string;
-  averagesData?: ChartData;
+  averagesData: ChartData;
   rollingAverage?: number;
   intervalsCount?: number;
   backgroundColor?: string;
@@ -45,30 +45,17 @@ function formatLabel(value: number, suffix: string) {
   return value + suffix;
 }
 
-function trimData(data: any[], days: number, rolling: number) {
-  const rollingOffset = Math.max(0, rolling - 1);
-  const trimLength = days + rollingOffset;
-  const excessLength = data.length - trimLength;
-  const trimmedData = excessLength > 0 ? data.slice(excessLength) : data;
-  return trimmedData.map((d) => Number(d) || 0);
-}
-
-function trimAxisData(axisData: any[], days: number) {
-  const excessLength = axisData.length - days;
-  return excessLength > 0 ? axisData.slice(excessLength) : axisData;
-}
-
 function roundNumber(num: number, places: number = 2) {
   return num.toFixed(Number.isInteger(num) ? 0 : places);
 }
 
 export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   title,
-  chartData: rawChartData,
-  axisData: rawAxisData,
-  averagesData: rawAveragesData = [],
+  chartData,
+  axisData,
+  averagesData,
   description,
-  rollingAverage = 0,
+  rollingAverage,
   days = 30,
   yMin = 5,
   ySuffix = '',
@@ -80,12 +67,10 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   const dateLocale = getDateLocaleOptions(i18n);
   const wideMonthLocales = ['bn'];
 
-  const daysLimit = Math.min(days, rawChartData.length, rawAxisData.length);
-  const intervalsCount = daysLimit < 30 ? 7 : 6;
+  const daysLimit = Math.min(days, chartData.length);
 
-  const chartData = trimData(rawChartData, daysLimit, rollingAverage);
-  const averagesData = trimData(rawAveragesData, daysLimit, rollingAverage);
-  const axisData = trimAxisData(rawAxisData, daysLimit);
+  // Arbitrary while data source is unstable, pending chart redesign
+  const intervalsCount = daysLimit < 30 ? 7 : 6;
 
   if (!chartData.length || !axisData.length) {
     return null;

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -49,7 +49,8 @@ function trimData(data: any[], days: number, rolling: number) {
   const rollingOffset = Math.max(0, rolling - 1);
   const trimLength = days + rollingOffset;
   const excessLength = data.length - trimLength;
-  return excessLength > 0 ? data.slice(excessLength) : data;
+  const trimmedData = excessLength > 0 ? data.slice(excessLength) : data;
+  return trimmedData.map((d) => Number(d) || 0);
 }
 
 function trimAxisData(axisData: any[], days: number) {
@@ -117,7 +118,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
     right: insetX
   };
 
-  // Where numbers are very small, don't labels like "0.5", or make one case look huge
+  // Where numbers are very small, no labels like "0.5" and don't make one case look huge
   const maxValue = chartData.reduce((max, value) => Math.max(max, value), 0);
   const yMax = maxValue < yMin ? yMin : undefined;
 

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -122,7 +122,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   const maxValue = chartData.reduce((max, value) => Math.max(max, value), 0);
   const yMax = maxValue < yMin ? yMin : undefined;
 
-  const showLegend = !!(rollingAverage || averagesData);
+  const showLegend = !!(rollingAverage || averagesData.length);
 
   return (
     <View

--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -79,7 +79,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
   const dateLocale = getDateLocaleOptions(i18n);
   const wideMonthLocales = ['bn'];
 
-  const daysLimit = Math.min(days, rawChartData.length);
+  const daysLimit = Math.min(days, rawChartData.length, rawAxisData.length);
   const intervalsCount = daysLimit < 30 ? 7 : 6;
 
   const chartData = trimData(rawChartData, daysLimit, rollingAverage);

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -26,7 +26,7 @@ const chartDataIsAvailable = (data: ExtractedData) => {
   return !!(data.axisData?.length && data.chartData?.length);
 };
 
-function trimData(data: any[], days: number, rolling: number) {
+export function trimData(data: any[], days: number, rolling: number) {
   const rollingOffset = Math.max(0, rolling - 1);
   const trimLength = days + rollingOffset;
   const excessLength = data.length - trimLength;
@@ -97,7 +97,7 @@ export const TrackerCharts: FC<TrackerChartsProps> = ({
   data,
   county = 'u',
   days = 30,
-  rollingAverage = 0
+  rollingAverage = 7 // If > 0, calculate in-app, don't use data from server
 }) => {
   const {t} = useTranslation();
 


### PR DESCRIPTION
 - [x] Use the app's own rolling average calculations instead of using them from the server (see below)
 - [x] Protection in case we ever get malformed or invalid dates
 - [x] Protection in case we ever get invalid numbers (e.g. numbers as strings)
 - [x] Centre rolling average lines against bars
 - [x] Apply data trimming 

Regarding point 1, there's something wrong with the rolling averages data we get from the server now on `prd`. I noticed it seemed to line up against the wrong dates, and after fixing that, it was fine for counties, but statewide, older values were coming in very wrong:

<img width=250 src="https://user-images.githubusercontent.com/29628323/92589433-74fb6180-f292-11ea-8f1e-9dea1ff9a1ea.jpg" /> <img width=250 src="https://user-images.githubusercontent.com/29628323/92589437-7593f800-f292-11ea-8e46-4063da664688.jpg" />

Fixing this on the server looks unrealistic (and I'm worried about what else would break). This PR reactivates (and updates) the code we had calculates rolling averages client-side:

<img width=250 src="https://user-images.githubusercontent.com/29628323/92589686-d4597180-f292-11ea-9d8d-c0c5d20e1c28.jpg" /> <img width=250 src="https://user-images.githubusercontent.com/29628323/92589689-d4f20800-f292-11ea-97ce-884c5d769a02.jpg" />