### PR TITLE
More resilience against out of bounds charts averages

### DIFF
--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -75,10 +75,12 @@ export const BarChartContent: FC<BarChartContentProps> = ({
     const lineGenerator = line();
     lineGenerator.curve(curveMonotoneX);
     const pathDef = lineGenerator(
-      averagesData.map((value, index) => [
-        (x(index) || 0) + bandwidth / 2,
-        y(value) || 0
-      ])
+      averagesData.reduce((points, value, index) => {
+        if (isNaN(x(index))) {
+          return points;
+        }
+        return [...points, [(x(index) || 0) + bandwidth / 2, y(value) || 0]];
+      }, [] as [number, number][])
     );
     return pathDef ? (
       <Path

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -50,23 +50,16 @@ function trimAxisData(axisData: any[], days: number) {
 
 const calculateRollingAverages = (
   rollingAverage: number,
-  chartData: ChartData,
-  days: number
+  chartData: ChartData
 ) => {
   const rollingOffset = Math.max(0, rollingAverage - 1);
-  return trimData(
-    rollingAverage
-      ? chartData.map((_, index) => {
-          const avStart = Math.max(0, index - rollingOffset);
-          const avEnd = index + 1;
-          const avValues = chartData.slice(avStart, avEnd);
-          const total = avValues.reduce((sum, num) => sum + num, 0);
-          return total / avValues.length;
-        })
-      : chartData,
-    days,
-    0
-  );
+  return chartData.map((_, index) => {
+    const avStart = Math.max(0, index - rollingOffset);
+    const avEnd = index + 1;
+    const avValues = chartData.slice(avStart, avEnd);
+    const total = avValues.reduce((sum, num) => sum + num, 0);
+    return total / avValues.length;
+  });
 };
 
 const getBarchartData = (
@@ -116,13 +109,13 @@ const getBarchartData = (
   // unless the server provided insufficient data
   const finalAveragesData =
     rollingAverage && chartData.length >= days + rollingAverage - 1
-      ? calculateRollingAverages(rollingAverage, chartData, days)
+      ? calculateRollingAverages(rollingAverage, chartData)
       : averagesData;
 
   return {
     chartData: trimData(chartData, days),
     axisData: trimAxisData(axisData, days),
-    averagesData: finalAveragesData
+    averagesData: trimData(finalAveragesData, days)
   };
 };
 


### PR DESCRIPTION
Doing a little investigation I found it was possible to get a big red line across the chart if there was somehow an averages entry from the server that was out of bounds on the right instead of the left.

With this change it simply ignores any out of bounds averages data.

Also simplifies some logic.