### PR TITLE
No double-render and a11y re-read on symptom select

### DIFF
--- a/src/components/views/symptom-checker/symptoms.tsx
+++ b/src/components/views/symptom-checker/symptoms.tsx
@@ -57,7 +57,7 @@ export const CheckInSymptoms = () => {
 
   const gotoResults = () => {
     try {
-      app.checkIn(app.checkerSymptoms, {feelingWell: false});
+      app.checkIn(symptoms, {feelingWell: false});
     } catch (err) {
       console.log('Check-in error', err);
     }

--- a/src/components/views/symptom-checker/symptoms.tsx
+++ b/src/components/views/symptom-checker/symptoms.tsx
@@ -75,18 +75,23 @@ export const CheckInSymptoms = () => {
     return values[symptom] ? [...selectedSymptoms, symptom] : selectedSymptoms;
   }, [] as Symptom[]);
 
-  const handleItemSelected = async (symptom: Symptom) => {
+  const handleItemSelected = (symptom: Symptom) => {
     const newValue = Number(!values[symptom]);
     setFieldValue(symptom, newValue, false);
     setSymptoms((s) => ({...s, [symptom]: newValue}));
 
-    await app.setContext({
-      checkerSymptoms: {
-        ...app.checkerSymptoms,
-        ...values,
-        [symptom]: newValue
-      }
-    });
+    setTimeout(
+      () =>
+        // Run this in next tick after re-render so a11y message isn't read twice
+        app.setContext({
+          checkerSymptoms: {
+            ...app.checkerSymptoms,
+            ...values,
+            [symptom]: newValue
+          }
+        }),
+      0
+    );
   };
 
   const onFeelingWell = () => {


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/245#issuecomment-687514574

Supersedes https://github.com/project-vagabond/covid-green-app/pull/361

Before, checking a symptom with screen reader on said "Not checked... Checked" and unchecking said "Checked... Not checked". This fixes it to just "Checked" and "Not checked".

Why: React Native can read the old and new a11y state of an item like a checkbox if there's a time delay during renders and re-renders after making a selection. We have this problem on the symptom checker checklist. In https://github.com/project-vagabond/covid-green-app/pull/361 I had tried to fix this using a 3rd-party package designed to fix this problem, but it's not well maintained and caused build issues.

Instead, I looked more into why we have slow re-renders and found that using a 0 timeout to update the app context in a separate tick on the event loop causes the press handler to complete earlier with just one state update render, solving the problem. 

We don't need the next render to wait for the app context to be updated because we can get everything we need from formik values and `symptoms` state.