### PR TITLE
Read dropdown a11y search label on changes on Android

### DIFF
--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -144,12 +144,6 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
   // on initial TextInput focus https://github.com/facebook/react-native/issues/26739
   const noPlaceholder = Platform.OS === 'android' && screenReaderEnabled;
 
-  console.log(
-    'instructions.......................',
-    typeof instructions,
-    instructions
-  );
-
   return (
     <Modal
       isVisible={true}

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -140,6 +140,10 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
     );
   };
 
+  // Workaround a RN bug where a placeholder prevents accessibilityLabel being read
+  // on initial TextInput focus https://github.com/facebook/react-native/issues/26739
+  const noPlaceholder = Platform.OS === 'android' && screenReaderEnabled;
+
   return (
     <Modal
       isVisible={true}
@@ -186,10 +190,11 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
                 }`}
                 style={[
                   styles.searchInput,
-                  !!search.term && styles.searchUnderlined
+                  !!search.term && styles.searchUnderlined,
+                  noPlaceholder && styles.noPlaceholder
                 ]}
                 placeholderTextColor={colors.text}
-                placeholder={search.placeholder}
+                placeholder={noPlaceholder ? '' : search.placeholder}
                 onChangeText={search.onChange}
                 value={search.term}
               />
@@ -242,6 +247,11 @@ const styles = StyleSheet.create({
   },
   icon: {
     paddingHorizontal: 16
+  },
+  noPlaceholder: {
+    minWidth: 100,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.black
   }
 });
 

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -34,6 +34,7 @@ interface DropdownModalProps extends Partial<ModalProps> {
     term: string;
     onChange: (value: string) => void;
     noResults: string;
+    noResultsLength: number;
   };
   itemRenderer?: (item: BasicItem) => ReactNode;
   instructions?: () => ReactNode;
@@ -59,6 +60,8 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
   } = useApplication();
   const searchInputRef = useRef<TextInput>(null);
   const [ref] = useFocusRef();
+  const searchHasResults =
+    search && items.length > (search.noResultsLength || 0);
 
   useEffect(() => {
     if (search && !screenReaderEnabled) {
@@ -115,19 +118,11 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
   };
 
   const renderContent = () => {
-    if (search) {
-      if (!search.term && instructions) {
-        return <View style={listStyles.contentWrapper}>{instructions()}</View>;
-      }
-
-      if (search.term && !items.length) {
-        return (
-          <View accessibilityElementsHidden style={listStyles.contentWrapper}>
-            <Text style={listStyles.noResults}>{search?.noResults}</Text>
-          </View>
-        );
-      }
+    if (search && !search.term && instructions) {
+      return <View style={listStyles.contentWrapper}>{instructions()}</View>;
     }
+
+    console.log('search', search);
 
     return (
       <KeyboardAvoidingView
@@ -137,6 +132,11 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
         enabled>
         <ScrollView keyboardShouldPersistTaps="always">
           {items.map(renderItem)}
+          {!!search?.term && !searchHasResults && (
+            <View accessibilityElementsHidden style={listStyles.contentWrapper}>
+              <Text style={listStyles.noResults}>{search?.noResults}</Text>
+            </View>
+          )}
         </ScrollView>
       </KeyboardAvoidingView>
     );
@@ -175,9 +175,9 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
                 ref={searchInputRef}
                 accessibilityRole="search"
                 accessibilityLabel={
-                  search.term && !items.length
+                  (!searchHasResults
                     ? t('county:noResultsHint')
-                    : t('county:searchHint')
+                    : t('county:searchHint'))
                 }
                 style={[
                   styles.searchInput,
@@ -230,7 +230,7 @@ const styles = StyleSheet.create({
     borderBottomColor: colors.dot
   },
   searchInput: {
-    ...text.default,
+    ...text.default
   },
   searchUnderlined: {
     textDecorationLine: 'underline'

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -172,15 +172,18 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
               <TextInput
                 ref={searchInputRef}
                 accessibilityRole="search"
-                accessibilityLabel={
-                  // Without changing the label, it isn't read on Android on starting input
-                  // https://github.com/facebook/react-native/issues/26739
-                  `${search.term}${search.term ? ', ' : ''}${
-                    !searchHasResults
-                      ? t('county:noResultsHint')
-                      : t('county:searchHint')
-                  }`
-                }
+                accessibilityLabel={`${
+                  // On Android but not iOS, on text input, accessibilityLabel is read if it has changed
+                  // but current value is not read. This tells user the full value after they stop typing
+                  // and tells them whether there are any autocomplete suggestions.
+                  Platform.OS === 'android' && search.term
+                    ? `${search.term}, `
+                    : ''
+                }${
+                  !searchHasResults
+                    ? t('county:noResultsHint')
+                    : t('county:searchHint')
+                }`}
                 style={[
                   styles.searchInput,
                   !!search.term && styles.searchUnderlined

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -249,9 +249,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16
   },
   noPlaceholder: {
-    minWidth: 100,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.black
+    minWidth: 150,
+    borderWidth: 2,
+    borderColor: colors.dot
   }
 });
 

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -130,7 +130,7 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
         enabled>
         <ScrollView keyboardShouldPersistTaps="always">
           {items.map(renderItem)}
-          {!!search?.term && !searchHasResults && (
+          {!!search?.term && !searchHasResults && !instructions && (
             <View accessibilityElementsHidden style={listStyles.contentWrapper}>
               <Text style={listStyles.noResults}>{search?.noResults}</Text>
             </View>
@@ -143,6 +143,12 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
   // Workaround a RN bug where a placeholder prevents accessibilityLabel being read
   // on initial TextInput focus https://github.com/facebook/react-native/issues/26739
   const noPlaceholder = Platform.OS === 'android' && screenReaderEnabled;
+
+  console.log(
+    'instructions.......................',
+    typeof instructions,
+    instructions
+  );
 
   return (
     <Modal

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -175,6 +175,9 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
                 ref={searchInputRef}
                 accessibilityRole="search"
                 accessibilityLabel={
+                  // Without changing the label, it isn't read on Android on starting input
+                  // https://github.com/facebook/react-native/issues/26739
+                  (search.term ? ' ' : '') +
                   (!searchHasResults
                     ? t('county:noResultsHint')
                     : t('county:searchHint'))

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -175,10 +175,11 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
                 accessibilityLabel={
                   // Without changing the label, it isn't read on Android on starting input
                   // https://github.com/facebook/react-native/issues/26739
-                  (search.term ? ' ' : '') +
-                  (!searchHasResults
-                    ? t('county:noResultsHint')
-                    : t('county:searchHint'))
+                  `${search.term}${search.term ? ', ' : ''}${
+                    !searchHasResults
+                      ? t('county:noResultsHint')
+                      : t('county:searchHint')
+                  }`
                 }
                 style={[
                   styles.searchInput,

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -122,8 +122,6 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
       return <View style={listStyles.contentWrapper}>{instructions()}</View>;
     }
 
-    console.log('search', search);
-
     return (
       <KeyboardAvoidingView
         keyboardVerticalOffset={insets.top + 12}

--- a/src/components/atoms/dropdown/selector.tsx
+++ b/src/components/atoms/dropdown/selector.tsx
@@ -18,6 +18,7 @@ export interface DropdownProps {
     term: string;
     onChange: (value: string) => void;
     noResults: string;
+    noResultsLength?: number;
     accessibilityLabel?: (selectedItem?: string) => string;
   };
   itemRenderer?: (item: BasicItem) => ReactNode;

--- a/src/components/molecules/county-dropdown.tsx
+++ b/src/components/molecules/county-dropdown.tsx
@@ -75,6 +75,7 @@ export const CountyDropdown: FC<CountyDropdownProps> = ({
         term: countySearch,
         onChange: onCountySearchChanged,
         noResults: t('county:noResults'),
+        noResultsLength: 1,
         accessibilityLabel: (selectedItem?: string) =>
           t('county:accessibilityLabel', {
             county: selectedItem


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/301 specifically https://github.com/project-vagabond/covid-green-app/issues/301#issuecomment-689802249

Two parts to the issue:

 - No matches isn't treated as no results because "All Counties" is always available therefore `items.length` is always >= 1
 - There's a bug in React Native's `TextInput` on Android where it doesn't read the accessibilityLabel as expected if the input has a value or placeholder: see https://github.com/facebook/react-native/issues/26739 in particular [this comment](https://github.com/facebook/react-native/issues/26739#issuecomment-625544804)

That issue suggests changing the accessibilityRole to `none` but that seems like an ugly hack likely to have side effects. Instead, we can use the fact that Android _does_ read the TextInput accessibility label on input if the label has changed.

I'm not sure exactly what behaviour we want. This way, we get the following:

 - On first input, it reads the full label stating whether there are suggestions or not
 - On further input, it reads the full label only if the text input flips whether there are suggestions or not

@floridemai Should the label be read after with every input?