### PR TITLE
Fix onboarding register spinner

### DIFF
--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -49,7 +49,7 @@ export const Permissions: FC<any> = () => {
     try {
       app.showActivityIndicator();
 
-      await app.clearContext();
+      await app.clearContext({loading: true});
       const {token, refreshToken} = await register();
       console.log(token, refreshToken);
 

--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -49,7 +49,6 @@ export const Permissions: FC<any> = () => {
     try {
       app.showActivityIndicator();
 
-      await app.clearContext();
       const {token, refreshToken} = await register();
       console.log(token, refreshToken);
 

--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -49,7 +49,7 @@ export const Permissions: FC<any> = () => {
     try {
       app.showActivityIndicator();
 
-      await app.clearContext({loading: true});
+      await app.clearContext();
       const {token, refreshToken} = await register();
       console.log(token, refreshToken);
 

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -67,7 +67,7 @@ interface State {
 export interface ApplicationContextValue extends State {
   uploadRequired?: boolean;
   setContext: (data: any) => Promise<void>;
-  clearContext: () => Promise<void>;
+  clearContext: (preservedState?: Partial<State>) => Promise<void>;
   showActivityIndicator: (message?: string) => void;
   hideActivityIndicator: () => void;
   loadAppData: () => Promise<void>;
@@ -259,7 +259,9 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     }
   };
 
-  const clearContext = async (): Promise<void> => {
+  const clearContext = async (
+    preservedState: Partial<State> = {}
+  ): Promise<void> => {
     await SecureStore.deleteItemAsync(StorageKeys.refreshToken);
     await SecureStore.deleteItemAsync(StorageKeys.token);
     await SecureStore.deleteItemAsync(StorageKeys.symptomKeys);
@@ -275,7 +277,8 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     await SecureStore.deleteItemAsync(StorageKeys.symptomDate);
     setState(() => ({
       ...initialState,
-      initializing: false
+      initializing: false,
+      ...preservedState
     }));
   };
 

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -67,7 +67,7 @@ interface State {
 export interface ApplicationContextValue extends State {
   uploadRequired?: boolean;
   setContext: (data: any) => Promise<void>;
-  clearContext: (preservedState?: Partial<State>) => Promise<void>;
+  clearContext: () => Promise<void>;
   showActivityIndicator: (message?: string) => void;
   hideActivityIndicator: () => void;
   loadAppData: () => Promise<void>;
@@ -259,9 +259,7 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     }
   };
 
-  const clearContext = async (
-    preservedState: Partial<State> = {}
-  ): Promise<void> => {
+  const clearContext = async (): Promise<void> => {
     await SecureStore.deleteItemAsync(StorageKeys.refreshToken);
     await SecureStore.deleteItemAsync(StorageKeys.token);
     await SecureStore.deleteItemAsync(StorageKeys.symptomKeys);
@@ -277,8 +275,7 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     await SecureStore.deleteItemAsync(StorageKeys.symptomDate);
     setState(() => ({
       ...initialState,
-      initializing: false,
-      ...preservedState
+      initializing: false
     }));
   };
 


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/411

Somewhere we added `clearContext` at the start of onboarding register action. Fine, but it also clears the loading state, making the user think they need to push the button again.