### PR TITLE
added the launch screen to be the screen seen when js is loading before app has swapped to js view

### DIFF
--- a/ios/COVIDGreen/AppDelegate.m
+++ b/ios/COVIDGreen/AppDelegate.m
@@ -22,8 +22,7 @@
                                                    moduleName:@"COVIDGreen"
                                             initialProperties:nil];
 
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:82/255.0f green:49/255.0f blue:120/255.0f alpha:1];
-
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
@@ -34,6 +33,9 @@
   center.delegate = self;
 
   [ExposureNotificationModule registerBackgroundProcessing];
+  UIView* launchScreenView = [[[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil] objectAtIndex:0];
+  launchScreenView.frame = self.window.bounds;
+  rootView.loadingView = launchScreenView;
   return YES;
 }
 

--- a/ios/COVIDGreen/AppDelegate.m
+++ b/ios/COVIDGreen/AppDelegate.m
@@ -22,7 +22,7 @@
                                                    moduleName:@"COVIDGreen"
                                             initialProperties:nil];
 
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:82/255.0f green:49/255.0f blue:120/255.0f alpha:1];
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;


### PR DESCRIPTION
Issue: [#141](https://github.com/project-vagabond/covid-green-app/issues/141)

Test on IOS and saw no screen flash.