### PR TITLE
Requested chart tweaks

### DIFF
--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -197,7 +197,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     minWidth: 60,
     borderRadius: 5,
-    backgroundColor: 'white',
+    backgroundColor: colors.white + 'E4',
     paddingBottom: 1
   },
   triangle: {

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -198,7 +198,7 @@ export const TrackerCharts: FC<TrackerChartsProps> = ({
               axisData={percentData.axisData}
               chartData={percentData.chartData}
               averagesData={percentData.averagesData}
-              yMin={0.5}
+              yMin={1}
               ySuffix="%"
             />
           </Card>


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/425

Slight translucency on bubble background:

<img width=420 src="https://user-images.githubusercontent.com/29628323/93069306-6daecc00-f675-11ea-8e6e-64102b4eadf6.png" />

1% minimum y max value: (doesn't change any counties)

<img width=420 src="https://user-images.githubusercontent.com/29628323/93069311-6e476280-f675-11ea-8a45-448946679e79.png" />
