### PR TITLE
Reset language to system language on uninstall

### DIFF
--- a/src/components/views/settings/language.tsx
+++ b/src/components/views/settings/language.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import {useTranslation} from 'react-i18next';
-import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-community/async-storage';
 
 import {Scrollable} from 'components/templates/scrollable';
 import {supportedLocales} from 'services/i18n/common';
@@ -38,7 +38,7 @@ export const Language = () => {
         items={languages}
         selectedValue={currentLanguage!.value}
         onItemSelected={(lang) => {
-          SecureStore.setItemAsync(StorageKeys.language, lang);
+          AsyncStorage.setItem(StorageKeys.language, lang);
           i18n.changeLanguage(lang);
         }}
       />

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -265,7 +265,7 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     await SecureStore.deleteItemAsync(StorageKeys.symptomKeys);
     await SecureStore.deleteItemAsync(StorageKeys.uploadToken);
     await SecureStore.deleteItemAsync(StorageKeys.callbackQueued);
-    await SecureStore.deleteItemAsync(StorageKeys.language);
+    await AsyncStorage.removeItem(StorageKeys.language);
     await AsyncStorage.removeItem(StorageKeys.user);
     await AsyncStorage.removeItem(StorageKeys.checkinConsent);
     await AsyncStorage.removeItem(StorageKeys.debug);

--- a/src/services/i18n/index.ts
+++ b/src/services/i18n/index.ts
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import {initReactI18next} from 'react-i18next';
 import * as Localization from 'expo-localization';
-import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-community/async-storage';
 import {
   fallback,
   defaultNamespace,
@@ -15,7 +15,7 @@ const languageDetector = {
   type: 'languageDetector',
   async: true,
   detect: async (callback: (lang: string) => void) => {
-    const storedLanguage = await SecureStore.getItemAsync(StorageKeys.language);
+    const storedLanguage = await AsyncStorage.getItem(StorageKeys.language);
     callback(
       storedLanguage || Localization.locale.split('-')[0].replace('-', '')
     );


### PR DESCRIPTION
WIP because I need to validate this, but it seems that the app can appear to fail to detect the system language if it has been installed then reinstalled if another language was set previously - because the language is saved in `SecureStore`.

Expected behaviour without this PR: (expected true of all supported languages, not just Spanish):

> Android device settings in Spanish, Uninstall app (was set to English in app) and install again = onboarding in Spanish
> iOS device settings in Spanish, Uninstall app and install = onboarding in English

Expected behaviour with this PR: after uninstall, onboarding is always in the device language if it's one of the supported languages.