### PR TITLE
Fix back behaviour on navigation to covid alert screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ import {CheckInSettings} from 'components/views/settings/check-in';
 import {Metrics} from 'components/views/settings/metrics';
 import {Leave} from 'components/views/settings/leave';
 import {Debug} from 'components/views/settings/debug';
-import {isMountedRef, navigationRef, ScreenNames} from 'navigation';
+import {covidAlertReset, isMountedRef, navigationRef, ScreenNames} from 'navigation';
 import {colors} from 'theme';
 import {Loading} from 'components/views/loading';
 import {useSymptomChecker} from 'hooks/symptom-checker';
@@ -414,7 +414,7 @@ function Navigation({
     }
 
     if (navigationRef.current && notification) {
-      navigationRef.current.navigate(ScreenNames.CloseContactAlert);
+      navigationRef.current.reset(covidAlertReset);
 
       setState((s) => ({...s, notification: null}));
     }
@@ -427,7 +427,7 @@ function Navigation({
 
     if (navigationRef.current && exposureNotificationClicked) {
       console.log('exposureNotificationClicked', exposureNotificationClicked);
-      navigationRef.current.navigate(ScreenNames.CloseContactAlert);
+      navigationRef.current.reset(covidAlertReset);
       setState((s) => ({...s, exposureNotificationClicked: null}));
     }
   }, [app, exposureNotificationClicked]);

--- a/src/components/atoms/navbar.tsx
+++ b/src/components/atoms/navbar.tsx
@@ -14,6 +14,7 @@ import Icons, {AppIcons} from 'assets/icons';
 import {colors, text} from 'theme';
 import {useApplication} from 'providers/context';
 import {TFunction} from 'i18next';
+import {useRoute, NavigationProp} from '@react-navigation/native';
 
 interface NavBarProps {
   navigation: any;
@@ -21,6 +22,11 @@ interface NavBarProps {
   placeholder?: boolean;
   modal?: boolean;
 }
+
+const getIndex = (routeKey: string, navigation: NavigationProp<any>) => {
+  const {routes} = navigation.dangerouslyGetState();
+  return routes.findIndex((route) => route.key === routeKey);
+};
 
 export const shareApp = async (t: TFunction) => {
   try {
@@ -49,15 +55,16 @@ export const NavBar: FC<NavBarProps> = ({
   const {t} = useTranslation();
   const insets = useSafeArea();
   const {user} = useApplication();
+  const {key: routeKey} = useRoute();
 
-  const [state, setState] = useState({back: false});
+  const [state, setState] = useState({back: getIndex(route, navigation) !== 0});
 
   useEffect(() => {
     let unsubscribeStart: (() => any) | null = null;
     let unsubscribeEnd: (() => any) | null = null;
     if (!placeholder) {
       unsubscribeStart = navigation.addListener('transitionStart', () => {
-        const {index} = navigation.dangerouslyGetState();
+        const index = getIndex(routeKey, navigation);
         setState((s) => ({
           ...s,
           back: index !== 0
@@ -65,7 +72,7 @@ export const NavBar: FC<NavBarProps> = ({
       });
 
       unsubscribeEnd = navigation.addListener('transitionEnd', () => {
-        const {index} = navigation.dangerouslyGetState();
+        const index = getIndex(routeKey, navigation);
         setState((s) => ({
           ...s,
           back: index > 0
@@ -77,7 +84,7 @@ export const NavBar: FC<NavBarProps> = ({
       unsubscribeStart && unsubscribeStart();
       unsubscribeEnd && unsubscribeEnd();
     };
-  }, [user, navigation, placeholder]);
+  }, [user, navigation, placeholder, routeKey]);
 
   return (
     <View style={[styles.wrapper, {paddingTop: insets.top + 2}]}>

--- a/src/components/atoms/navbar.tsx
+++ b/src/components/atoms/navbar.tsx
@@ -9,13 +9,11 @@ import {
 } from 'react-native';
 import {useTranslation} from 'react-i18next';
 import {useSafeArea} from 'react-native-safe-area-context';
-import {useRoute} from '@react-navigation/native';
 
 import Icons, {AppIcons} from 'assets/icons';
 import {colors, text} from 'theme';
 import {useApplication} from 'providers/context';
 import {TFunction} from 'i18next';
-import {ScreenNames} from 'navigation';
 
 interface NavBarProps {
   navigation: any;
@@ -51,7 +49,6 @@ export const NavBar: FC<NavBarProps> = ({
   const {t} = useTranslation();
   const insets = useSafeArea();
   const {user} = useApplication();
-  const route = useRoute();
 
   const [state, setState] = useState({back: false});
 
@@ -90,11 +87,7 @@ export const NavBar: FC<NavBarProps> = ({
             <TouchableWithoutFeedback
               accessibilityRole="button"
               accessibilityHint={t('navbar:backHint')}
-              onPress={() => {
-                route && route.name === ScreenNames.CloseContactAlert
-                  ? navigation.navigate(ScreenNames.MyCovidAlerts)
-                  : navigation.goBack();
-              }}>
+              onPress={() => navigation.goBack()}>
               <View
                 hitSlop={{left: 12, right: 12, top: 8, bottom: 8}}
                 style={styles.back}>

--- a/src/components/atoms/navbar.tsx
+++ b/src/components/atoms/navbar.tsx
@@ -57,7 +57,7 @@ export const NavBar: FC<NavBarProps> = ({
   const {user} = useApplication();
   const {key: routeKey} = useRoute();
 
-  const [state, setState] = useState({back: getIndex(route, navigation) !== 0});
+  const [state, setState] = useState({back: false});
 
   useEffect(() => {
     let unsubscribeStart: (() => any) | null = null;

--- a/src/components/molecules/close-contact-warning.tsx
+++ b/src/components/molecules/close-contact-warning.tsx
@@ -4,7 +4,7 @@ import {useExposure} from 'react-native-exposure-notification-service';
 import {useNavigation} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
 
-import {ScreenNames} from 'navigation';
+import {covidAlertReset, ScreenNames} from 'navigation';
 
 import {Card} from 'components/atoms/card';
 
@@ -22,7 +22,7 @@ export const CloseContactWarning = forwardRef<TouchableWithoutFeedback>(
       <Card
         ref={ref}
         padding={{h: 10, r: 16}}
-        onPress={() => navigation.navigate(ScreenNames.CloseContactAlert)}
+        onPress={() => navigation.reset(covidAlertReset)}
         type="warning">
         <View style={styles.row}>
           <StateIcons.ExposureAlert

--- a/src/components/views/close-contact-alert.tsx
+++ b/src/components/views/close-contact-alert.tsx
@@ -1,10 +1,9 @@
 import React, {FC, useEffect, useState} from 'react';
-import {Linking, StyleSheet, View} from 'react-native';
+import {StyleSheet, View, Linking} from 'react-native';
 import {useExposure} from 'react-native-exposure-notification-service';
 import PushNotification from 'react-native-push-notification';
 import {useTranslation} from 'react-i18next';
 import {format, subDays} from 'date-fns';
-import {useNavigation} from '@react-navigation/native';
 
 import {Card} from 'components/atoms/card';
 import {Markdown} from 'components/atoms/markdown';
@@ -13,11 +12,10 @@ import {CallCard} from 'components/molecules/call-card';
 import {Scrollable} from 'components/templates/scrollable';
 
 import {getDateLocaleOptions} from 'services/i18n/date';
-import {colors, text} from 'theme';
+import {text, colors} from 'theme';
 import {StateIcons} from 'assets/icons';
 
 import {renderListBullet} from './close-contact-info';
-import {ScreenNames} from 'navigation';
 
 const markdownStyles = {
   text: {
@@ -33,16 +31,6 @@ export const CloseContactAlert: FC = () => {
   const {t, i18n} = useTranslation();
   const exposure = useExposure();
   const [closeContactDate, setCloseContactDate] = useState<string>('');
-  const navigation = useNavigation();
-
-  useEffect(() => {
-    return navigation.addListener('focus', () => {
-      navigation.reset({
-        index: 0,
-        routes: [{name: ScreenNames.MyCovidAlerts}]
-      });
-    });
-  }, [navigation]);
 
   useEffect(() => {
     async function getCloseContactDate() {

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -33,3 +33,12 @@ export enum ScreenNames {
   Dashboard = 'dashboard',
   Settings = 'settings'
 }
+
+// Always navigate to CloseContactAlert so that back action takes user to MyCovidAlerts
+export const covidAlertReset = {
+  index: 1,
+  routes: [
+    {name: ScreenNames.MyCovidAlerts},
+    {name: ScreenNames.CloseContactAlert}
+  ]
+};

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -38,7 +38,7 @@ export enum ScreenNames {
 export const covidAlertReset = {
   index: 1,
   routes: [
-    {name: ScreenNames.MyCovidAlerts},
+    {name: 'main', params: { screen: ScreenNames.MyCovidAlerts }},
     {name: ScreenNames.CloseContactAlert}
   ]
 };


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/446

- Replaces https://github.com/project-vagabond/covid-green-app/pull/402 with a cleaner solution
- Replaces the iOS workaround in that PR, which seemed to cause the Android bug in the above issue, with a more direct fix for the underlying bug in `NavBar` that gets whether the _screen_ not the _navigator_ has history.

Explaining that bug: `navigation` is  specific to a navigator, not to a route or screen, so `navigation.dangerouslyGetState()` in NavBar doesn't know which screen is calling it. If it's called from the screen that is `0` in the `routes` array and has no history but another screen on this navigator is in focus, it'll return a non-0 `index` value in the screen with no history.

On iOS, on reset to MyCovidAlerts then CloseContactAlert, both screens call animation handlers, so both screens call `navigation.dangerouslyGetState()`, and both screens see that the `navigation` state has index `1`, so both show back buttons. When `CloseContactAlert` screen is popped off the stack, `MyCovidAlerts` doesn't need to animate so it keeps the back button it rendered while `CloseContactAlert` was on the stack. 

https://github.com/project-vagabond/covid-green-app/pull/402/commits/a071a0c903e0c1a298aa0bb2b3fca91dfdc9b3e0 dodged this on iOS by navigating to `MyCovidAlerts` instead of using `goBack()`. On iOS, the navigate action calls the animation handler, removing the back button as a side effect; but stack navigation animation handling is different between platforms and it seems Android doesn't animate as a side effect of being navigated to when already rendered like this.

The fix here avoids all of this by finding the route index of the _screen_ the header is actually in, not the route index of the navigation state which could be a completely different screen. It seems to work well on both Android and iOS (please test more on iOS).

---

In doing this I also stumbled upon what appears to be a simple way to remove the delay before the back button appears. Last commit _removes_ this because I couldn't remember if this delay was a deliberate design decision or a reluctant compromise. It should probably be in its own PR if we do want that change (and would probably also allow dropping the animation callbacks).