### PR TITLE
No delay before back button

### DIFF
--- a/src/components/atoms/navbar.tsx
+++ b/src/components/atoms/navbar.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useEffect, useState} from 'react';
+import React, {FC} from 'react';
 import {
   StyleSheet,
   Text,
@@ -12,9 +12,8 @@ import {useSafeArea} from 'react-native-safe-area-context';
 
 import Icons, {AppIcons} from 'assets/icons';
 import {colors, text} from 'theme';
-import {useApplication} from 'providers/context';
 import {TFunction} from 'i18next';
-import {useRoute, NavigationProp} from '@react-navigation/native';
+import {useRoute, NavigationProp, useNavigationState} from '@react-navigation/native';
 
 interface NavBarProps {
   navigation: any;
@@ -22,11 +21,6 @@ interface NavBarProps {
   placeholder?: boolean;
   modal?: boolean;
 }
-
-const getIndex = (routeKey: string, navigation: NavigationProp<any>) => {
-  const {routes} = navigation.dangerouslyGetState();
-  return routes.findIndex((route) => route.key === routeKey);
-};
 
 export const shareApp = async (t: TFunction) => {
   try {
@@ -54,43 +48,18 @@ export const NavBar: FC<NavBarProps> = ({
 }) => {
   const {t} = useTranslation();
   const insets = useSafeArea();
-  const {user} = useApplication();
-  const {key: routeKey} = useRoute();
+  const {key: routeKey, name} = useRoute();
+  const routes = useNavigationState(state => state.routes);
+  const index = routes.findIndex((route) => route.key === routeKey);
+  const hasHistory = !placeholder && index > 0;
 
-  const [state, setState] = useState({back: false});
-
-  useEffect(() => {
-    let unsubscribeStart: (() => any) | null = null;
-    let unsubscribeEnd: (() => any) | null = null;
-    if (!placeholder) {
-      unsubscribeStart = navigation.addListener('transitionStart', () => {
-        const index = getIndex(routeKey, navigation);
-        setState((s) => ({
-          ...s,
-          back: index !== 0
-        }));
-      });
-
-      unsubscribeEnd = navigation.addListener('transitionEnd', () => {
-        const index = getIndex(routeKey, navigation);
-        setState((s) => ({
-          ...s,
-          back: index > 0
-        }));
-      });
-    }
-
-    return () => {
-      unsubscribeStart && unsubscribeStart();
-      unsubscribeEnd && unsubscribeEnd();
-    };
-  }, [user, navigation, placeholder, routeKey]);
+  console.log('route --- ', index, name)
 
   return (
     <View style={[styles.wrapper, {paddingTop: insets.top + 2}]}>
       <View style={styles.container}>
         <View style={[styles.col, styles.left]}>
-          {state.back && (
+          {hasHistory && (
             <TouchableWithoutFeedback
               accessibilityRole="button"
               accessibilityHint={t('navbar:backHint')}

--- a/src/components/atoms/navbar.tsx
+++ b/src/components/atoms/navbar.tsx
@@ -53,8 +53,6 @@ export const NavBar: FC<NavBarProps> = ({
   const index = routes.findIndex((route) => route.key === routeKey);
   const hasHistory = !placeholder && index > 0;
 
-  console.log('route --- ', index, name)
-
   return (
     <View style={[styles.wrapper, {paddingTop: insets.top + 2}]}>
       <View style={styles.container}>


### PR DESCRIPTION
Variant on https://github.com/project-vagabond/covid-green-app/pull/451 that cleanly removes the need for a delay before showing the back button.

As far as I can tell, because the previous approach used `index` from `navigation.dangerouslyGetState()` which represents the index of the focused screen in the current navigator, when a screen that wasn't in focus renders it could show the wrong back button state; and this could happen when a screen rendered behind another screen on the stack or when a new screen initially rendered before it animated in, before it was considered the navigator's focused screen. By getting the index of the actual screen this navbar is in, we don't need to attach to animation which is handled differently in ios and android.

Seems to work everywhere on Android and iOS, but I don't know exactly what edge cases the back button delay was added to fix so this is just an experimental draft for now, we might want to save this for after the release