### PR TITLE
Keep app.initializing until load() completes or fails

### DIFF
--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -224,7 +224,6 @@ export const AP = ({appConfig, user, consent, children}: API) => {
       load();
     } catch (err) {
       console.log('App init error:', err);
-    } finally {
       setState((s) => ({...s, initializing: false}));
     }
   }, []);


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/463 and should catch a bunch of similar issues.

Previously (since the first commit in this repo) we've had this:

```ts
    try {
      load();
    } catch (err) {
      console.log('App init error:', err);
    } finally {
      setState((s) => ({...s, initializing: false}));
    }
```

But `load` is async, so the app `initializing` state becomes `false` almost instantly, and doesn't wait until `load()` completes. With this change, the app state doesn't become initialised until `load()` has completed, so on app launch the loading screen stays very slightly longer until the app state is ready and has loaded what it needs from storage.

@floridemai I'm not sure of the history of why it was like this, so please check in case there was a reason for almost instantly becoming initialised!