### PR TITLE
Fix 458 - Show date immediately on close contact alert screen

### DIFF
--- a/src/components/views/close-contact-alert.tsx
+++ b/src/components/views/close-contact-alert.tsx
@@ -58,7 +58,8 @@ export const CloseContactAlert: FC = () => {
 
   PushNotification.setApplicationIconBadgeNumber(0);
 
-  // Asyncronously update contacts once, re-rendering if it wasn't not up to date
+  // getCloseContacts() asyncronously updates RNENS's contacts state.
+  // If we were showing old cached data, it'll quickly re-render showing up to date data
   useEffect(() => {
     getCloseContacts();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/views/close-contact-alert.tsx
+++ b/src/components/views/close-contact-alert.tsx
@@ -56,22 +56,18 @@ export const CloseContactAlert: FC = () => {
   const {t, i18n} = useTranslation();
   const {contacts, getCloseContacts} = useExposure();
 
+  PushNotification.setApplicationIconBadgeNumber(0);
+
+  // Asyncronously update contacts once, re-rendering if it wasn't not up to date
   useEffect(() => {
-    PushNotification.setApplicationIconBadgeNumber(0);
-
-    // Calling this asyncronously updates contacts, re-rendering if it's not up to date
     getCloseContacts();
-
-    // Only call once as exposure context data will update each time
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const closeContactDate = getContactDate(contacts, getDateLocaleOptions(i18n));
 
-  const refreshing = !contacts || !contacts.length;
-
   return (
-    <Scrollable refresh={{refreshing, onRefresh: getCloseContacts}}>
+    <Scrollable>
       <Card padding={{h: 0, v: 0}}>
         <View style={styles.cardImage}>
           <StateIcons.ErrorPhone height={144} width={144} />

--- a/src/components/views/close-contact-alert.tsx
+++ b/src/components/views/close-contact-alert.tsx
@@ -19,6 +19,8 @@ import {text, colors} from 'theme';
 import {StateIcons} from 'assets/icons';
 
 import {renderListBullet} from './close-contact-info';
+import { Loading } from './loading';
+import Spinner from 'react-native-loading-spinner-overlay';
 
 const markdownStyles = {
   text: {
@@ -39,7 +41,7 @@ const getContactDate = (
   dateLocale: DateLocale
 ): string => {
   if (!contacts || !contacts.length) {
-    return '…';
+    return '';
   }
 
   const closeContact = contacts[0];
@@ -54,7 +56,7 @@ const getContactDate = (
 
 export const CloseContactAlert: FC = () => {
   const {t, i18n} = useTranslation();
-  const {contacts, getCloseContacts} = useExposure();
+  const {contacts, getCloseContacts, initialised} = useExposure();
 
   PushNotification.setApplicationIconBadgeNumber(0);
 
@@ -63,12 +65,15 @@ export const CloseContactAlert: FC = () => {
   useEffect(() => {
     getCloseContacts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [initialised]);
 
   const closeContactDate = getContactDate(contacts, getDateLocaleOptions(i18n));
 
+  const appIsLoading = !closeContactDate && !initialised;
+
   return (
     <Scrollable>
+      <Spinner animation="fade" visible={appIsLoading} />
       <Card padding={{h: 0, v: 0}}>
         <View style={styles.cardImage}>
           <StateIcons.ErrorPhone height={144} width={144} />


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/458

I thought this would be really tricky and had set up a whole thing caching the contact in `context` until I realised we could get that already from the exposure service. Done this way, the screen will also update if the contacts list changes. 