### PR TITLE
added button on press debounce support

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-native-svg-charts": "^5.4.0",
     "react-native-unimodules": "^0.10.1",
     "react-native-video": "^4.4.5",
+    "throttle-debounce": "^2.3.0",
     "yup": "^0.29.3"
   },
   "devDependencies": {
@@ -82,6 +83,7 @@
     "@types/react-native-push-notification": "^3.0.8",
     "@types/react-native-svg-charts": "^5.0.3",
     "@types/react-test-renderer": "16.9.2",
+    "@types/throttle-debounce": "^2.1.0",
     "@types/yup": "^0.29.3",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",

--- a/src/components/atoms/button.tsx
+++ b/src/components/atoms/button.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Dimensions
 } from 'react-native';
+import {debounce} from 'throttle-debounce';
 
 import {text, scale, colors} from 'theme';
 
@@ -18,6 +19,7 @@ interface ButtonProps {
   onPress: () => void;
   style?: ViewStyle;
   width?: number | string;
+  debounceDelay?: number;
   children: React.ReactNode;
 }
 
@@ -29,6 +31,7 @@ export const Button: React.FC<ButtonProps> = ({
   onPress,
   style,
   width,
+  debounceDelay = 0,
   children
 }) => {
   const [pressed, setPressed] = useState(false);
@@ -61,15 +64,16 @@ export const Button: React.FC<ButtonProps> = ({
     }
   }
 
+  const onPressHandler = () => {
+    setPressed(false);
+    onPress();
+  };
   const pressHandlers = disabled
     ? {}
     : {
         onPressIn: () => setPressed(true),
         onPressOut: () => setPressed(false),
-        onPress: () => {
-          setPressed(false);
-          onPress();
-        }
+        onPress: !debounceDelay ? onPressHandler : debounce(500, onPressHandler)
       };
 
   return (

--- a/src/components/views/symptom-checker/symptoms.tsx
+++ b/src/components/views/symptom-checker/symptoms.tsx
@@ -127,6 +127,7 @@ export const CheckInSymptoms = () => {
           width="100%"
           type="empty"
           onPress={onFeelingWell}
+          debounceDelay={500}
           disabled={!!enableContinue}>
           {t('checker:feelingWell')}
         </Button>
@@ -139,7 +140,10 @@ export const CheckInSymptoms = () => {
           onItemSelected={handleItemSelected}
         />
         <Spacing s={36} />
-        <Button onPress={gotoResults} disabled={!enableContinue}>
+        <Button
+          onPress={gotoResults}
+          debounceDelay={500}
+          disabled={!enableContinue}>
           {t('checker:symptoms:nextButton')}
         </Button>
       </Card>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,6 +1583,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/throttle-debounce@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz#1c3df624bfc4b62f992d3012b84c56d41eab3776"
+  integrity sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -8042,6 +8047,11 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+
+throttle-debounce@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
+  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
 
 through2@^2.0.0, through2@^2.0.1:
   version "2.0.5"


### PR DESCRIPTION
Issue: https://github.com/project-vagabond/covid-green-app/issues/492

The current PR fixes the mentioned issue, but there are some things to consider moving forward:
- how can we prevent double navigation (even with debounce/throttle)
- are there any other places with fire/forget that we need to handle (in most of the cases we use the spinner)
