### PR TITLE
Failsafe for age gate screen

### DIFF
--- a/src/components/views/onboarding/age-check/age-check.tsx
+++ b/src/components/views/onboarding/age-check/age-check.tsx
@@ -32,6 +32,7 @@ export const AgeCheck: FC<{}> = () => {
           accessibilityLabel={t('common:longName')}>
           <Icons.Logo width={106} height={121} />
         </View>
+        <View style={style.flexSpacer} />
         <View style={style.contentWrapper}>
           <Text style={style.text} maxFontSizeMultiplier={1.4} ref={ref}>
             {t('ageCheck:intro')}
@@ -45,6 +46,7 @@ export const AgeCheck: FC<{}> = () => {
             {t('ageCheck:confirm')}
           </Button>
         </View>
+        <View style={style.flexSpacer} />
         <View style={style.flexSpacer} />
       </View>
       <View style={style.stateLogoWrapper}>
@@ -64,9 +66,9 @@ const style = StyleSheet.create({
     flexGrow: 1
   },
   appLogoWrapper: {
-    flex: 2,
+    flex: 4,
     alignItems: 'center',
-    justifyContent: 'center'
+    justifyContent: 'flex-end'
   },
   contentWrapper: {
     alignItems: 'flex-start',

--- a/src/components/views/onboarding/age-check/age-check.tsx
+++ b/src/components/views/onboarding/age-check/age-check.tsx
@@ -45,6 +45,7 @@ export const AgeCheck: FC<{}> = () => {
             {t('ageCheck:confirm')}
           </Button>
         </View>
+        <View style={style.flexSpacer} />
       </View>
       <View style={style.stateLogoWrapper}>
         <Image accessibilityIgnoresInvertColors source={HealthLogo} />
@@ -68,10 +69,12 @@ const style = StyleSheet.create({
     justifyContent: 'center'
   },
   contentWrapper: {
-    flex: 3,
     alignItems: 'flex-start',
-    justifyContent: 'flex-start',
+    justifyContent: 'flex-end',
     paddingHorizontal: SPACING_HORIZONTAL
+  },
+  flexSpacer: {
+    flex: 1
   },
   text: {
     ...text.xlarge,

--- a/src/components/views/onboarding/age-check/age-check.tsx
+++ b/src/components/views/onboarding/age-check/age-check.tsx
@@ -34,14 +34,14 @@ export const AgeCheck: FC<{}> = () => {
         </View>
         <View style={style.flexSpacer} />
         <View style={style.contentWrapper}>
-          <Text style={style.text} maxFontSizeMultiplier={1.4} ref={ref}>
+          <Text style={style.text} maxFontSizeMultiplier={1.3} ref={ref}>
             {t('ageCheck:intro')}
           </Text>
           <Spacing s={20} />
           <Button
             type="empty"
             width="100%"
-            fontSizeMultiplier={1.4}
+            fontSizeMultiplier={1.3}
             onPress={() => nav.navigate(ScreenNames.Introduction)}>
             {t('ageCheck:confirm')}
           </Button>

--- a/src/components/views/onboarding/age-check/age-check.tsx
+++ b/src/components/views/onboarding/age-check/age-check.tsx
@@ -66,7 +66,7 @@ const style = StyleSheet.create({
     flexGrow: 1
   },
   appLogoWrapper: {
-    flex: 4,
+    flex: 3,
     alignItems: 'center',
     justifyContent: 'flex-end'
   },

--- a/src/components/views/onboarding/age-check/age-check.tsx
+++ b/src/components/views/onboarding/age-check/age-check.tsx
@@ -33,14 +33,14 @@ export const AgeCheck: FC<{}> = () => {
           <Icons.Logo width={106} height={121} />
         </View>
         <View style={style.contentWrapper}>
-          <Text style={style.text} maxFontSizeMultiplier={1.7} ref={ref}>
+          <Text style={style.text} maxFontSizeMultiplier={1.4} ref={ref}>
             {t('ageCheck:intro')}
           </Text>
           <Spacing s={20} />
           <Button
             type="empty"
             width="100%"
-            fontSizeMultiplier={1.7}
+            fontSizeMultiplier={1.4}
             onPress={() => nav.navigate(ScreenNames.Introduction)}>
             {t('ageCheck:confirm')}
           </Button>


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/512

I used the Android split screen feature to simulate small devices. Goals are:

 - In all reasonable, foreseeable scenarios (including a partially-sighted Russian non-English speaker using the smallest known device we support), show the full app logo, readable text, pressable button and DOH logo, as nicely spaced as possible 
 - In any possible unreasonable, unforeseeable scenarios (e.g. a fad for small square phones breaks out in October or there's some case we missed in testing), ensure that it degrades gracefully and the text and button are prioritised.

I've simulated that using the Android split screen feature. This is in Russian (longest text) at maximum enlarged font size in increasingly unreasonable scenarios:

<img width=350 src="https://user-images.githubusercontent.com/29628323/94026903-2ed5f000-fdb2-11ea-89d9-2d0e9e95fc52.jpg" />

<img width=350 src="https://user-images.githubusercontent.com/29628323/94026905-2f6e8680-fdb2-11ea-9392-bd0fbe13274e.jpg" />

<img width=350 src="https://user-images.githubusercontent.com/29628323/94026908-30071d00-fdb2-11ea-8f11-16a80b09fac1.jpg" />

<img width=350 src="https://user-images.githubusercontent.com/29628323/94026910-30071d00-fdb2-11ea-8e87-e865a6e24449.jpg" />
 
This is it at normal font size:

<img width=350 src="https://user-images.githubusercontent.com/29628323/94026980-47dea100-fdb2-11ea-81c3-95266ceb3df9.jpg" />