### PR TITLE
#469: Cleaner counties modal behaviour on Android 

### DIFF
--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -7,7 +7,8 @@ import {
   ScrollView,
   View,
   Text,
-  TextInput
+  TextInput,
+  TouchableOpacity
 } from 'react-native';
 import Modal, {ModalProps} from 'react-native-modal';
 import {useSafeArea} from 'react-native-safe-area-context';
@@ -21,7 +22,6 @@ import {Spacing} from 'components/atoms/layout';
 
 import {text, colors} from 'theme';
 import {AppIcons} from 'assets/icons';
-import {TouchableOpacity} from 'react-native-gesture-handler';
 
 interface DropdownModalProps extends Partial<ModalProps> {
   title: string;

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -66,7 +66,11 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
 
   useEffect(() => {
     if (search && !screenReaderEnabled) {
-      searchInputRef.current?.focus();
+      const focusInput = () => searchInputRef.current?.focus();
+
+      // On Android, bringing up the keyboard during render causes juddering
+      // and can cause sizes to end up incorrectly calculated
+      Platform.OS === 'android' ? setTimeout(focusInput, 400) : focusInput();
     }
   }, []);
 


### PR DESCRIPTION
Small code changes to fix two things:

 - First commit: for #517 - a recent fix for something else caused the 'X' icon on the Counties dropdown modal to stop working (verfied on two Android devices, both in latest nys and build 46 from play store). Works with this change.
 - Second commit: for #469 - the juddering I saw seems to be cause by the keyboard coming into view while the dropdown items list is still rendering and there seem to be some random possible timing glitches depending on the random order things happen. This seems to stop that and makes the whole thing much smaller, ensuring the list has content and is sized correctly before bringing up the keyboard.