### PR TITLE
Disabling the tag build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,6 @@
 name: Build and Push to Fastlane
 on:
+  release:
 #  push:
 #    tags:
 #      - v1.*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 name: Build and Push to Fastlane
-#on:
+on:
 #  push:
 #    tags:
 #      - v1.*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,8 @@
 name: Build and Push to Fastlane
-on:
-  push:
-    tags:
-      - v1.*
+#on:
+#  push:
+#    tags:
+#      - v1.*
 
 jobs:
   android-build:


### PR DESCRIPTION
Temporarily disabling the build trigger during the initial app release.