### PR TITLE
#529: Add "Prefer not to say" as default county

### DIFF
--- a/src/providers/settings.tsx
+++ b/src/providers/settings.tsx
@@ -288,7 +288,8 @@ function getAgeRangeOptions(t: TFunction): AgeOption[] {
 
 function getCountiesOptions(t: TFunction): BasicItem[] {
   return [
-    {label: t('county:notinny'), value: 'u'},
+    {label: t('common:preferNotToSay'), value: 'u'},
+    {label: t('county:notinny'), value: 'other'},
     ...counties.map((c) => ({label: c.county, value: c.code}))
   ];
 }


### PR DESCRIPTION
For https://github.com/project-vagabond/covid-green-app/issues/529

This is a small change code-wise, but I'd like @colmharte to check it because it semi-reverts part of https://github.com/project-vagabond/covid-green-app/pull/47 and because there are implications for the metrics analysis which I don't have visibility on.

Because of https://github.com/project-vagabond/covid-green-app/issues/529 users of 1.0.0 initial release who activate the symptom checker and report a value of `u` for county will be a mix of:

 - People who skipped demographics or deliberately left county unset
 - People who actively chose "Not in New York"

For v1.0.1+ we will separate the two, but we need to decide what to do with users who were set as `u` while using v1.0.0. As I see it there are three possibilities:

1. Treat them as "Prefer not to say", using `u` for "Prefer not to say" going forward like all other demographics, and if any 1.0.0 `u` users are actually not from  New York and want that known, they can set that in settings. **This is what this PR does**
2. Treat them as "Not in New York", keeping `u` for that label and giving Prefer Not To Says another value. This looks like a bad idea and a high risk of creating a misleadingly high number of "Not in New York" users in the first set of data.
3. Treat them as a special case, reserving `u` for these users and creating two new values. This would allow these users to be excluded from any county-based data analysis that is done, but I don't know if it is necessary or not (I'd expect "prefer not to says" would be excluded anyway and if not, if app version is already included in these users' metrics, then they can already be differentiated) 

It looks to me like 1 is the best option, 2 is a no-go and  just adds unnecessary complication but it's worth confirming that.