### PR TITLE
Read date string with same timezone as format()

### DIFF
--- a/src/components/molecules/bar-chart.tsx
+++ b/src/components/molecules/bar-chart.tsx
@@ -120,7 +120,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
     let date = '';
     try {
       date = format(
-        new Date(axisData[index]),
+        axisData[index],
         wideMonthLocales.includes(i18n.language) ? 'Mo' : 'MMM',
         dateLocale
       );
@@ -139,7 +139,7 @@ export const TrackerBarChart: FC<TrackerBarChartProps> = ({
     }
     let date = '';
     try {
-      date = format(new Date(axisData[index]), 'dd');
+      date = format(axisData[index], 'dd');
     } catch (err) {
       // Error already logged generating accessibility text
     }

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -115,7 +115,7 @@ const getBarchartData = (
     averagesData = reducedData.averagesData;
   } else {
     data.forEach((record) => {
-      axisData.push(new Date(record.test_date || record.last_test_date));
+      axisData.push(parseDateString(record.test_date || record.last_test_date));
       chartData.push(record[quantityKey]);
       if (averagesKey) {
         averagesData.push(record[averagesKey]);
@@ -137,8 +137,8 @@ const getBarchartData = (
   };
 };
 
-const getComparableDate = (date: Date | string) => {
-  return format(new Date(date), 'yyyy-mm-dd');
+const getComparableDate = (date: Date) => {
+  return format(date, 'yyyy-mm-dd');
 };
 
 export const TrackerCharts: FC<TrackerChartsProps> = ({

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -1,6 +1,6 @@
 import React, {FC} from 'react';
 import {useTranslation} from 'react-i18next';
-import {format} from 'date-fns';
+import {format, parseISO} from 'date-fns';
 
 import {Spacing} from 'components/atoms/spacing';
 import {Card} from 'components/atoms/card';
@@ -79,7 +79,7 @@ const getBarchartData = (
       (records, date: string, index: number) => {
         const dataRecord = data[date] || data[index];
         return {
-          axisData: [...records.axisData, new Date(date)],
+          axisData: [...records.axisData, parseISO(date.split('T')[0])],
           chartData: [...records.chartData, dataRecord[quantityKey]],
           averagesData: averagesKey
             ? [...records.averagesData, dataRecord[averagesKey]]

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -31,8 +31,14 @@ const getEmptyExtractedData = (): ExtractedData => {
   return emptyData;
 };
 
+const dateIsValid = (date: Date) => !isNaN(Number(date));
+
 const chartDataIsAvailable = (data: ExtractedData) => {
-  return !!(data.axisData?.length && data.chartData?.length);
+  return !!(
+    data.axisData?.length &&
+    data.chartData?.length &&
+    data.axisData?.every(dateIsValid)
+  );
 };
 
 export function trimData(data: any[], days: number, rolling: number = 0) {
@@ -53,8 +59,8 @@ function parseDateString(dateString: string) {
   // On Android (but not iOS), west of GMT this causes formatted dates to be -1 day
   let date = parseISO(dateString);
 
-  // Don't crash if the server changes date format unexpectedly
-  if (isNaN(Number(date))) {
+  // Don't fail if the server changes date format unexpectedly
+  if (!dateIsValid(date)) {
     console.log(
       `dateString not in ISO format: "${dateString}" (${typeof dateString})`
     );

--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -61,9 +61,6 @@ function parseDateString(dateString: string) {
 
   // Don't fail if the server changes date format unexpectedly
   if (!dateIsValid(date)) {
-    console.log(
-      `dateString not in ISO format: "${dateString}" (${typeof dateString})`
-    );
     const utcDate = new Date(dateString);
     const offsetMinutes = utcDate.getTimezoneOffset();
     date = add(utcDate, {minutes: offsetMinutes});


### PR DESCRIPTION
No issue for this but it fixes an issue in some reports Fahd forwarded me by email: some users reported seeing different dates in the charts to other users, despite seeing the same data. Supplied screenshots showed Android devices with the charts' dates displayed as one day before the charts in iOS devices and the official data source. 

Looking into this it seems that on Android but not iOS, the device timezone offset is applied to the chart dates got from the server after parsing it as a UTC date; and because these are sent as midnight on the date the data refers to, in all timezones with an offset less than 0 (i.e. all of the Americas but not Europe), the dates display one day too early.

`date-fns`'s format function always formats the date in the device timezone, so we should ensure we parse the date string in the device timezone too so that the offset doesn't change the date.

- [x] Read date string with same timezone as format()
- [x] Test in-device on Android
- [x] Verify that this fix works across Android versions (tested on 6, 9, 10)
- [x] Verify that there are no negative side effects on iOS
- [x] Make the date parsing more resilient to unexpected server-side changes
- [x] Check for any other logic parsing then formatting date strings from the API that might be affected
 