### PR TITLE
Add analyticsConsent to app context and ExposureProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -535,8 +535,8 @@ const ExposureApp: React.FC = ({children}) => {
       authToken={tokens.authToken}
       refreshToken={tokens.refreshToken}
       notificationTitle={t('closeContactNotification:title')}
-      notificationDescription={t('closeContactNotification:description')}>
-      analyticsConsent={analyticsConsent}
+      notificationDescription={t('closeContactNotification:description')}
+      analyticsOptin={analyticsConsent}>
       {children}
     </ExposureProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -499,7 +499,7 @@ const ExposureApp: React.FC = ({children}) => {
   }>({authToken: '', refreshToken: ''});
 
   const settings = useSettings();
-  const app = useApplication();
+  const {analyticsConsent, user} = useApplication();
 
   useEffect(() => {
     async function getTokens() {
@@ -520,15 +520,13 @@ const ExposureApp: React.FC = ({children}) => {
     }
 
     getTokens();
-  }, [app.user]);
+  }, [user]);
 
   const version = getReadableVersion();
 
   return (
     <ExposureProvider
-      isReady={Boolean(
-        app.user?.valid && tokens.authToken && tokens.refreshToken
-      )}
+      isReady={Boolean(user?.valid && tokens.authToken && tokens.refreshToken)}
       traceConfiguration={settings.traceConfiguration}
       appVersion={version}
       serverUrl={urls.api}
@@ -538,6 +536,7 @@ const ExposureApp: React.FC = ({children}) => {
       refreshToken={tokens.refreshToken}
       notificationTitle={t('closeContactNotification:title')}
       notificationDescription={t('closeContactNotification:description')}>
+      analyticsConsent={analyticsConsent}
       {children}
     </ExposureProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -499,7 +499,7 @@ const ExposureApp: React.FC = ({children}) => {
   }>({authToken: '', refreshToken: ''});
 
   const settings = useSettings();
-  const {analyticsConsent, user} = useApplication();
+  const {analyticsOptIn, user} = useApplication();
 
   useEffect(() => {
     async function getTokens() {
@@ -536,7 +536,7 @@ const ExposureApp: React.FC = ({children}) => {
       refreshToken={tokens.refreshToken}
       notificationTitle={t('closeContactNotification:title')}
       notificationDescription={t('closeContactNotification:description')}
-      analyticsOptin={analyticsConsent}>
+      analyticsOptin={analyticsOptIn}>
       {children}
     </ExposureProvider>
   );

--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -48,6 +48,7 @@ export const Permissions: FC<any> = () => {
   const handleRegistration = async (skip: boolean) => {
     try {
       app.showActivityIndicator();
+      const analyticsConsent = true;
 
       const {token, refreshToken} = await register();
       console.log(token, refreshToken);
@@ -58,13 +59,14 @@ export const Permissions: FC<any> = () => {
         refreshToken,
         {}
       );
-      await SecureStore.setItemAsync(StorageKeys.analytics, String(true), {});
+      await SecureStore.setItemAsync(StorageKeys.analytics, String(analyticsConsent), {});
 
       await app.setContext({
         user: {
           new: true,
           valid: true
-        }
+        },
+        analyticsConsent
       });
 
       app.hideActivityIndicator();

--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -48,7 +48,7 @@ export const Permissions: FC<any> = () => {
   const handleRegistration = async (skip: boolean) => {
     try {
       app.showActivityIndicator();
-      const analyticsConsent = true;
+      const analyticsOptIn = true;
 
       const {token, refreshToken} = await register();
       console.log(token, refreshToken);
@@ -59,14 +59,14 @@ export const Permissions: FC<any> = () => {
         refreshToken,
         {}
       );
-      await SecureStore.setItemAsync(StorageKeys.analytics, String(analyticsConsent), {});
+      await SecureStore.setItemAsync(StorageKeys.analytics, String(analyticsOptIn), {});
 
       await app.setContext({
         user: {
           new: true,
           valid: true
         },
-        analyticsConsent
+        analyticsOptIn
       });
 
       app.hideActivityIndicator();

--- a/src/components/views/settings/metrics.tsx
+++ b/src/components/views/settings/metrics.tsx
@@ -13,10 +13,10 @@ import {useApplication} from 'providers/context';
 export const Metrics = () => {
   const {t} = useTranslation();
   const {configure} = useExposure();
-  const {analyticsConsent, setContext} = useApplication();
+  const {analyticsOptIn, setContext} = useApplication();
 
   const toggleSwitch = async () => {
-    setContext({analyticsConsent: !analyticsConsent});
+    setContext({analyticsOptIn: !analyticsOptIn});
     configure();
   };
 
@@ -42,7 +42,7 @@ export const Metrics = () => {
             }}
             thumbColor={colors.white}
             onValueChange={toggleSwitch}
-            value={analyticsConsent}
+            value={analyticsOptIn}
           />
         </View>
       </View>

--- a/src/components/views/settings/metrics.tsx
+++ b/src/components/views/settings/metrics.tsx
@@ -1,7 +1,6 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import {useTranslation} from 'react-i18next';
 import {Text, Switch, View, StyleSheet} from 'react-native';
-import * as SecureStore from 'expo-secure-store';
 
 import {colors, text} from 'theme';
 import {DataProtectionLink} from 'components/views/data-protection-policy';
@@ -9,30 +8,15 @@ import {Markdown} from 'components/atoms/markdown';
 import {Spacing} from 'components/atoms/spacing';
 import {useExposure} from 'react-native-exposure-notification-service';
 import {Scrollable} from 'components/templates/scrollable';
-import {StorageKeys} from 'providers/context';
+import {useApplication} from 'providers/context';
 
 export const Metrics = () => {
   const {t} = useTranslation();
   const {configure} = useExposure();
-  const [enabled, setEnabled] = useState(false);
-  useEffect(() => {
-    SecureStore.getItemAsync(StorageKeys.analytics)
-      .then((consent) => {
-        if (consent) {
-          setEnabled(consent === 'true');
-        }
-      })
-      .catch((err) => console.log(err));
-  }, []);
+  const {analyticsConsent, setContext} = useApplication();
 
   const toggleSwitch = async () => {
-    if (enabled) {
-      setEnabled(false);
-      SecureStore.setItemAsync(StorageKeys.analytics, String(false), {});
-    } else {
-      setEnabled(true);
-      SecureStore.setItemAsync(StorageKeys.analytics, String(true), {});
-    }
+    setContext({analyticsConsent: !analyticsConsent});
     configure();
   };
 
@@ -58,7 +42,7 @@ export const Metrics = () => {
             }}
             thumbColor={colors.white}
             onValueChange={toggleSwitch}
-            value={enabled}
+            value={analyticsConsent}
           />
         </View>
       </View>

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -107,7 +107,7 @@ export interface API {
 }
 
 export enum StorageKeys {
-  analytics = 'analyticsOptIn',
+  analytics = 'analyticsConsent',
   canSupportENS = 'supportPossible',
   uploadToken = 'uploadToken',
   symptomDate = 'symptomDate',

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -268,8 +268,8 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     await AsyncStorage.removeItem(StorageKeys.user);
     await AsyncStorage.removeItem(StorageKeys.checkinConsent);
     await AsyncStorage.removeItem(StorageKeys.debug);
-    await AsyncStorage.removeItem(StorageKeys.analytics);
     await AsyncStorage.removeItem(StorageKeys.county);
+    await SecureStore.deleteItemAsync(StorageKeys.analytics);
     await SecureStore.deleteItemAsync(StorageKeys.canSupportENS);
     await SecureStore.deleteItemAsync(StorageKeys.symptomDate);
     setState(() => ({

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -215,7 +215,7 @@ export const AP = ({appConfig, user, consent, children}: API) => {
         StorageKeys.analytics
       );
       if (analyticsOptInStr) {
-        analyticsOptIn = analyticsOptInStr === 'true';
+        analyticsOptIn = analyticsOptInStr === String(true);
       }
 
       setState((s) => ({
@@ -263,13 +263,13 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     if (data.callBackQueuedTs) {
       await SecureStore.setItemAsync(
         StorageKeys.callbackQueued,
-        JSON.stringify(data.callBackQueuedTs)
+        String(data.callBackQueuedTs)
       );
     }
     if (data.analyticsOptIn !== undefined) {
       await SecureStore.setItemAsync(
         StorageKeys.analytics,
-        JSON.stringify(data.analyticsOptIn)
+        String(data.analyticsOptIn)
       );
     }
   };

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -53,7 +53,7 @@ interface State {
   loading: boolean | string;
   user?: User;
   data?: StatsData | null;
-  analyticsConsent: boolean;
+  analyticsOptIn: boolean;
   checkInConsent: boolean;
   completedChecker: boolean;
   completedCheckerDate: string | null;
@@ -81,7 +81,7 @@ const initialState = {
   initializing: true,
   loading: false,
   user: undefined,
-  analyticsConsent: false,
+  analyticsOptIn: false,
   completedChecker: false,
   completedCheckerDate: null,
   checkerSymptoms: {} as SymptomRecord,
@@ -107,7 +107,7 @@ export interface API {
 }
 
 export enum StorageKeys {
-  analytics = 'analyticsConsent',
+  analytics = 'analyticsOptIn',
   canSupportENS = 'supportPossible',
   uploadToken = 'uploadToken',
   symptomDate = 'symptomDate',
@@ -180,7 +180,7 @@ export const AP = ({appConfig, user, consent, children}: API) => {
       let checks: Check[] = [];
       let completedCheckerDate: string | null = null;
       let completedChecker = false;
-      let analyticsConsent = false;
+      let analyticsOptIn = false;
 
       if (state.user) {
         const checksData = await SecureStore.getItemAsync(
@@ -211,17 +211,17 @@ export const AP = ({appConfig, user, consent, children}: API) => {
       }
 
       const county = await AsyncStorage.getItem(StorageKeys.county);
-      const analyticsConsentStr = await SecureStore.getItemAsync(
+      const analyticsOptInStr = await SecureStore.getItemAsync(
         StorageKeys.analytics
       );
-      if (analyticsConsentStr) {
-        analyticsConsent = analyticsConsentStr === 'true';
+      if (analyticsOptInStr) {
+        analyticsOptIn = analyticsOptInStr === 'true';
       }
 
       setState((s) => ({
         ...s,
         initializing: false,
-        analyticsConsent,
+        analyticsOptIn,
         completedChecker,
         completedCheckerDate,
         checks,
@@ -266,10 +266,10 @@ export const AP = ({appConfig, user, consent, children}: API) => {
         JSON.stringify(data.callBackQueuedTs)
       );
     }
-    if (data.analyticsConsent !== undefined) {
+    if (data.analyticsOptIn !== undefined) {
       await SecureStore.setItemAsync(
         StorageKeys.analytics,
-        JSON.stringify(data.analyticsConsent)
+        JSON.stringify(data.analyticsOptIn)
       );
     }
   };

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -439,10 +439,10 @@ export enum METRIC_TYPES {
 
 export async function saveMetric({event = ''}) {
   try {
-    const analyticsConsent = await SecureStore.getItemAsync(
+    const analyticsOptIn = await SecureStore.getItemAsync(
       StorageKeys.analytics
     );
-    if (!analyticsConsent || (analyticsConsent && analyticsConsent !== 'true')) {
+    if (!analyticsOptIn || (analyticsOptIn && analyticsOptIn !== 'true')) {
       return false;
     }
     const os = Platform.OS;

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -442,7 +442,7 @@ export async function saveMetric({event = ''}) {
     const analyticsOptIn = await SecureStore.getItemAsync(
       StorageKeys.analytics
     );
-    if (!analyticsOptIn || (analyticsOptIn && analyticsOptIn !== 'true')) {
+    if (analyticsOptIn !== String(true)) {
       return false;
     }
     const os = Platform.OS;

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -439,10 +439,10 @@ export enum METRIC_TYPES {
 
 export async function saveMetric({event = ''}) {
   try {
-    const analyticsOptin = await SecureStore.getItemAsync(
+    const analyticsConsent = await SecureStore.getItemAsync(
       StorageKeys.analytics
     );
-    if (!analyticsOptin || (analyticsOptin && analyticsOptin !== 'true')) {
+    if (!analyticsConsent || (analyticsConsent && analyticsConsent !== 'true')) {
       return false;
     }
     const os = Platform.OS;


### PR DESCRIPTION
Similar approach to https://github.com/nearform/pennsylvania-covid-tracker/pull/163

Testing:

- [x] Analytics on, turn it off, restart app: stays off
- [x] Analytics off, turn it on, restart app, stays on
- [x] Analytics off, use "delete data", re-register, defaults to on
- [x] Analytics on, use "delete data", don't re-register, store state is undefined
- [x] Analytics is on, turn it off, don't restart app, analytics in RNENS is off
- [x] Analytics is off, turn it on, don't restart app, analytics in RNENS is on

@floridemai This is now fully tested