### PR TITLE
Wrap app in Suspense with Loading fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {Suspense, useEffect, useState} from 'react';
 import {enableScreens} from 'react-native-screens';
 import {Platform, StatusBar, Image, AppState} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
@@ -609,35 +609,37 @@ export default function App(props: {
 
   return (
     <SafeAreaProvider>
-      <Base>
-        <SettingsProvider>
-          <SettingsContext.Consumer>
-            {(settingsValue) => {
-              if (!settingsValue.loaded) {
-                return <Loading />;
-              }
-              return (
-                <ApplicationProvider
-                  user={settingsValue.user}
-                  consent={settingsValue.consent}
-                  appConfig={settingsValue.appConfig}>
-                  <ExposureApp>
-                    <StatusBar barStyle="default" />
-                    <Navigation
-                      traceConfiguration={settingsValue.traceConfiguration}
-                      notification={state.notification}
-                      exposureNotificationClicked={
-                        state.exposureNotificationClicked
-                      }
-                      setState={setState}
-                    />
-                  </ExposureApp>
-                </ApplicationProvider>
-              );
-            }}
-          </SettingsContext.Consumer>
-        </SettingsProvider>
-      </Base>
+      <Suspense fallback={<Loading />}>
+        <Base>
+          <SettingsProvider>
+            <SettingsContext.Consumer>
+              {(settingsValue) => {
+                if (!settingsValue.loaded) {
+                  return <Loading />;
+                }
+                return (
+                  <ApplicationProvider
+                    user={settingsValue.user}
+                    consent={settingsValue.consent}
+                    appConfig={settingsValue.appConfig}>
+                    <ExposureApp>
+                      <StatusBar barStyle="default" />
+                      <Navigation
+                        traceConfiguration={settingsValue.traceConfiguration}
+                        notification={state.notification}
+                        exposureNotificationClicked={
+                          state.exposureNotificationClicked
+                        }
+                        setState={setState}
+                      />
+                    </ExposureApp>
+                  </ApplicationProvider>
+                );
+              }}
+            </SettingsContext.Consumer>
+          </SettingsProvider>
+        </Base>
+      </Suspense>
     </SafeAreaProvider>
   );
 }


### PR DESCRIPTION
<strike>Draft, needs testing / validation.</strike>

We've seen some errors with stack traces like:

```
com.facebook.react.common.JavascriptException: Error: A React component suspended while rendering, but no fallback UI was specified.
Add a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display.
    in Unknown
    in RCTView
    in View
    in Unknown
    in RNCSafeAreaProvider
    in Unknown
    in Unknown
    in RCTView
    in View
    in RCTView
    in View
    in C
```

We're not consciously using any async logic that requries Suspense but it's possible that dependencies are e.g. i18n in particular.

Needs testing e.g. I've kept the Safe Area Provider outside because Loading needs it but we should make sure that's  not what's causing the error.