### PR TITLE
#562 - Clear symptoms on uninstall, reset language on leave

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import {useRtl} from 'hooks/i18n';
 import {
   ApplicationProvider,
   useApplication,
-  StorageKeys
+  SecureStoreKeys
 } from 'providers/context';
 import {
   SettingsProvider,
@@ -508,10 +508,10 @@ const ExposureApp: React.FC = ({children}) => {
     async function getTokens() {
       try {
         const storedAuthToken = await SecureStore.getItemAsync(
-          StorageKeys.token
+          SecureStoreKeys.token
         );
         const storedRefreshToken = await SecureStore.getItemAsync(
-          StorageKeys.refreshToken
+          SecureStoreKeys.refreshToken
         );
         setTokens({
           authToken: storedAuthToken || '',

--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -7,7 +7,7 @@ import * as SecureStore from 'expo-secure-store';
 
 import {ScreenNames} from 'navigation';
 import {register} from 'services/api';
-import {useApplication, StorageKeys} from 'providers/context';
+import {useApplication, SecureStoreKeys} from 'providers/context';
 import {useFocusRef} from 'hooks/accessibility';
 
 import {Button} from 'components/atoms/button';
@@ -41,7 +41,7 @@ export const Permissions: FC<any> = () => {
 
   useEffect(() => {
     if (!exposure.supported && exposure.canSupport) {
-      SecureStore.setItemAsync(StorageKeys.canSupportENS, 'true');
+      SecureStore.setItemAsync(SecureStoreKeys.canSupportENS, 'true');
     }
   }, []);
 
@@ -53,13 +53,17 @@ export const Permissions: FC<any> = () => {
       const {token, refreshToken} = await register();
       console.log(token, refreshToken);
 
-      await SecureStore.setItemAsync(StorageKeys.token, token);
+      await SecureStore.setItemAsync(SecureStoreKeys.token, token);
       await SecureStore.setItemAsync(
-        StorageKeys.refreshToken,
+        SecureStoreKeys.refreshToken,
         refreshToken,
         {}
       );
-      await SecureStore.setItemAsync(StorageKeys.analytics, String(analyticsOptIn), {});
+      await SecureStore.setItemAsync(
+        SecureStoreKeys.analytics,
+        String(analyticsOptIn),
+        {}
+      );
 
       await app.setContext({
         user: {

--- a/src/components/views/settings/index.tsx
+++ b/src/components/views/settings/index.tsx
@@ -20,7 +20,7 @@ import {Card} from 'components/atoms/card';
 import {Spacing} from 'components/atoms/layout';
 import {colors, text, shadows} from 'theme';
 import {ScreenNames} from 'navigation';
-import {StorageKeys} from 'providers/context';
+import {AsyncStorageKeys} from 'providers/context';
 
 const REQUIRED_PRESS_COUNT = 3;
 
@@ -48,7 +48,7 @@ export const Settings: React.FC<SettingsProps> = ({navigation}) => {
   const versionPressHandler = async () => {
     setPressCount(pressCount + 1);
     if (!showDebug && pressCount + 1 >= REQUIRED_PRESS_COUNT) {
-      await AsyncStorage.setItem(StorageKeys.debug, 'y');
+      await AsyncStorage.setItem(AsyncStorageKeys.debug, 'y');
       setShowDebug(true);
     }
   };
@@ -56,13 +56,15 @@ export const Settings: React.FC<SettingsProps> = ({navigation}) => {
   useEffect(() => {
     const init = async () => {
       try {
-        const showDebugData = await AsyncStorage.getItem(StorageKeys.debug);
+        const showDebugData = await AsyncStorage.getItem(
+          AsyncStorageKeys.debug
+        );
         if (showDebugData) {
           setShowDebug(showDebugData === 'y');
         }
       } catch (err) {
         console.log(
-          `Error reading "${StorageKeys.debug}" from async storage:`,
+          `Error reading "${AsyncStorageKeys.debug}" from async storage:`,
           err
         );
       }

--- a/src/components/views/settings/language.tsx
+++ b/src/components/views/settings/language.tsx
@@ -8,7 +8,7 @@ import {supportedLocales, fallback} from 'services/i18n/common';
 import {Markdown} from 'components/atoms/markdown';
 import {SelectList} from 'components/atoms/select-list';
 import {Spacing} from 'components/atoms/layout';
-import {StorageKeys} from 'providers/context';
+import {AsyncStorageKeys} from 'providers/context';
 
 interface LanguageType {
   value: string;
@@ -39,7 +39,7 @@ export const Language = () => {
         items={languages}
         selectedValue={currentLanguage!.value}
         onItemSelected={(lang) => {
-          AsyncStorage.setItem(StorageKeys.language, lang);
+          AsyncStorage.setItem(AsyncStorageKeys.language, lang);
           i18n.changeLanguage(lang);
         }}
       />

--- a/src/components/views/settings/leave.tsx
+++ b/src/components/views/settings/leave.tsx
@@ -1,20 +1,23 @@
-import React from 'react';
+import React, {FC} from 'react';
 import {Alert, View, Platform} from 'react-native';
 import {useTranslation} from 'react-i18next';
 import * as Haptics from 'expo-haptics';
+import {NavigationProp} from '@react-navigation/native';
+import {useExposure} from 'react-native-exposure-notification-service';
+
+import {ScreenNames} from 'navigation';
+import {getDeviceLanguage} from 'services/i18n';
+import {forget, networkError} from 'services/api';
+import {useApplication} from 'providers/context';
 
 import {Button} from 'components/atoms/button';
-import {DataProtectionLink} from 'components/views/data-protection-policy';
-import {forget, networkError} from 'services/api';
 import {Markdown} from 'components/atoms/markdown';
 import {Spacing} from 'components/atoms/spacing';
-import {useApplication} from 'providers/context';
-import {useExposure} from 'react-native-exposure-notification-service';
 import {PinnedBottom} from 'components/templates/pinned';
-import {ScreenNames} from 'navigation';
+import {DataProtectionLink} from 'components/views/data-protection-policy';
 
-export const Leave = ({navigation}) => {
-  const {t} = useTranslation();
+export const Leave: FC<{navigation: NavigationProp<any>}> = ({navigation}) => {
+  const {t, i18n} = useTranslation();
   const app = useApplication();
   const exposure = useExposure();
   const confirmed = async () => {
@@ -28,6 +31,7 @@ export const Leave = ({navigation}) => {
       }
       await forget();
       await app.clearContext();
+      i18n.changeLanguage(getDeviceLanguage());
 
       app.hideActivityIndicator();
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -4,7 +4,7 @@ import * as SecureStore from 'expo-secure-store';
 import {useTranslation} from 'react-i18next';
 import {useExposure} from 'react-native-exposure-notification-service';
 
-import {useApplication, StorageKeys} from 'providers/context';
+import {useApplication, SecureStoreKeys} from 'providers/context';
 import {
   validateCode,
   uploadExposureKeys,
@@ -50,9 +50,11 @@ export const UploadKeys = ({navigation}) => {
   useEffect(() => {
     const readUploadToken = async () => {
       try {
-        const token = await SecureStore.getItemAsync(StorageKeys.uploadToken);
+        const token = await SecureStore.getItemAsync(
+          SecureStoreKeys.uploadToken
+        );
         const storedSymptomDate = await SecureStore.getItemAsync(
-          StorageKeys.symptomDate
+          SecureStoreKeys.symptomDate
         );
         if (token && storedSymptomDate) {
           setUploadToken(token);
@@ -91,8 +93,8 @@ export const UploadKeys = ({navigation}) => {
     }
 
     try {
-      await SecureStore.setItemAsync(StorageKeys.uploadToken, token!);
-      await SecureStore.setItemAsync(StorageKeys.symptomDate, symptomDate!);
+      await SecureStore.setItemAsync(SecureStoreKeys.uploadToken, token!);
+      await SecureStore.setItemAsync(SecureStoreKeys.symptomDate, symptomDate!);
     } catch (e) {
       console.log('Error (secure) storing upload token', e);
     }
@@ -138,8 +140,8 @@ export const UploadKeys = ({navigation}) => {
     }
 
     try {
-      await SecureStore.deleteItemAsync(StorageKeys.uploadToken);
-      await SecureStore.deleteItemAsync(StorageKeys.symptomDate);
+      await SecureStore.deleteItemAsync(SecureStoreKeys.uploadToken);
+      await SecureStore.deleteItemAsync(SecureStoreKeys.symptomDate);
     } catch (e) {}
   };
 

--- a/src/hooks/i18n.tsx
+++ b/src/hooks/i18n.tsx
@@ -5,7 +5,7 @@ import {I18nManager} from 'react-native';
 import {useNavigation, useNavigationState} from '@react-navigation/native';
 import RNRestarter from 'react-native-restart';
 
-import {StorageKeys} from 'providers/context';
+import {AsyncStorageKeys} from 'providers/context';
 import {ScreenNames} from 'navigation';
 
 const languagesReset = {
@@ -27,7 +27,7 @@ export const useRtl = () => {
   const routeName = routes.length ? routes[routes.length - 1].name : '';
 
   const navigation = useNavigation();
-  const screenRef = useRef<RestartStatus>({ routeName, isRestarting: false });
+  const screenRef = useRef<RestartStatus>({routeName, isRestarting: false});
 
   const langIsRtl = i18n.dir() === 'rtl';
   const appIsRtl = I18nManager.isRTL;
@@ -40,17 +40,18 @@ export const useRtl = () => {
 
       I18nManager.allowRTL(langIsRtl);
       I18nManager.forceRTL(langIsRtl);
-      AsyncStorage.setItem(StorageKeys.restartScreen, screenRef.current.routeName).then(
-        () => RNRestarter.Restart()
-      );
+      AsyncStorage.setItem(
+        AsyncStorageKeys.restartScreen,
+        screenRef.current.routeName
+      ).then(() => RNRestarter.Restart());
     }
   }, [langIsRtl, appIsRtl]);
 
   useEffect(() => {
     // After forced restart, return to language settings if that's where we were
-    AsyncStorage.getItem(StorageKeys.restartScreen).then((screenName) => {
+    AsyncStorage.getItem(AsyncStorageKeys.restartScreen).then((screenName) => {
       if (screenName) {
-        AsyncStorage.setItem(StorageKeys.restartScreen, '').then(() => {
+        AsyncStorage.setItem(AsyncStorageKeys.restartScreen, '').then(() => {
           if (screenName === ScreenNames.LanguageSetttings) {
             navigation.reset(languagesReset);
           }

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -215,8 +215,6 @@ export const AP = ({appConfig, user, consent, children}: API) => {
           checks = checksData ? JSON.parse(checksData) : [];
         }
 
-        console.log({checks, checksData, legacyChecksData});
-
         checks.sort((a, b) => compareDesc(a.timestamp, b.timestamp));
 
         if (checks.length) {

--- a/src/providers/settings.tsx
+++ b/src/providers/settings.tsx
@@ -18,7 +18,7 @@ import {AllHtmlEntities} from 'html-entities';
 import * as api from 'services/api';
 import {fallback} from 'services/i18n/common';
 import {counties} from 'assets/counties';
-import {StorageKeys} from './context';
+import {AsyncStorageKeys} from './context';
 
 export interface BasicItem {
   label: string;
@@ -162,8 +162,8 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({children}) => {
   useEffect(() => {
     const loadSettingsAsync = async () => {
       const [user, consent] = await AsyncStorage.multiGet([
-        StorageKeys.user,
-        StorageKeys.checkinConsent
+        AsyncStorageKeys.user,
+        AsyncStorageKeys.checkinConsent
       ]);
 
       let apiSettings: ApiSettings;

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -12,7 +12,7 @@ import {getReadableVersion} from 'react-native-device-info';
 import {CallBackData} from 'components/organisms/phone-number-us';
 
 import {urls} from 'constants/urls';
-import {Check, StorageKeys} from 'providers/context';
+import {Check, SecureStoreKeys} from 'providers/context';
 import {isMountedRef, navigationRef, ScreenNames} from 'navigation';
 import {County} from 'assets/counties';
 import {configureNetInfo, testNetinfo} from './netinfo';
@@ -84,7 +84,7 @@ export const request = async (url: string, cfg: any) => {
   const {authorizationHeaders = false, ...config} = cfg;
 
   if (authorizationHeaders) {
-    let bearerToken = await SecureStore.getItemAsync(StorageKeys.token);
+    let bearerToken = await SecureStore.getItemAsync(SecureStoreKeys.token);
     if (!bearerToken) {
       bearerToken = await createToken();
     }
@@ -135,7 +135,7 @@ export const request = async (url: string, cfg: any) => {
 async function createToken(): Promise<string> {
   try {
     const refreshToken = await SecureStore.getItemAsync(
-      StorageKeys.refreshToken
+      SecureStoreKeys.refreshToken
     );
 
     const req = await request(`${urls.api}/refresh`, {
@@ -154,7 +154,7 @@ async function createToken(): Promise<string> {
       throw new Error('Error getting token');
     }
 
-    await SecureStore.setItemAsync(StorageKeys.token, resp.token);
+    await SecureStore.setItemAsync(SecureStoreKeys.token, resp.token);
 
     saveMetric({event: METRIC_TYPES.TOKEN_RENEWAL});
 
@@ -440,7 +440,7 @@ export enum METRIC_TYPES {
 export async function saveMetric({event = ''}) {
   try {
     const analyticsOptIn = await SecureStore.getItemAsync(
-      StorageKeys.analytics
+      SecureStoreKeys.analytics
     );
     if (analyticsOptIn !== String(true)) {
       return false;

--- a/src/services/i18n/index.ts
+++ b/src/services/i18n/index.ts
@@ -9,13 +9,13 @@ import {
   supportedLocales
 } from './common';
 import {format as F} from 'date-fns';
-import {StorageKeys} from 'providers/context';
+import {AsyncStorageKeys} from 'providers/context';
 
 const languageDetector = {
   type: 'languageDetector',
   async: true,
   detect: async (callback: (lang: string) => void) => {
-    const storedLanguage = await AsyncStorage.getItem(StorageKeys.language);
+    const storedLanguage = await AsyncStorage.getItem(AsyncStorageKeys.language);
     callback(
       storedLanguage || Localization.locale.split('-')[0].replace('-', '')
     );

--- a/src/services/i18n/index.ts
+++ b/src/services/i18n/index.ts
@@ -11,21 +11,25 @@ import {
 import {format as F} from 'date-fns';
 import {AsyncStorageKeys} from 'providers/context';
 
-const languageDetector = {
+export const getDeviceLanguage = () => {
+  const lang = Localization.locale.split('-')[0].replace('-', '');
+  return Object.keys(supportedLocales).includes(lang) ? lang : fallback;
+};
+
+export const languageDetector = {
   type: 'languageDetector',
   async: true,
   detect: async (callback: (lang: string) => void) => {
-    const storedLanguage = await AsyncStorage.getItem(AsyncStorageKeys.language);
-    callback(
-      storedLanguage || Localization.locale.split('-')[0].replace('-', '')
+    const storedLanguage = await AsyncStorage.getItem(
+      AsyncStorageKeys.language
     );
+    callback(storedLanguage || getDeviceLanguage());
   },
   init: () => {},
   cacheUserLanguage: () => {}
-};
+} as const;
 
 i18n
-  // @ts-ignore
   .use(languageDetector)
   .use(initReactI18next)
   .init({


### PR DESCRIPTION
For #562

Previously `SecureStore` had been chosen for symptoms checker history. This isn't ideal because users uninstalling the app would be unlikely to expect their symptom history to persist (although users selecting "leave" in settings will still have their symptoms history removed). SecureStore is also not generally intended for growing data like daily symptoms history.

This migrates symptoms history to AsyncStorage, checking for legacy data in SecureStore and merging and de-duping it if there is any. It seems robust from my testing, including edge cases like testflight users downgrading their app to versions before this PR, but **please do test thoroughly**!

This PR also tidies up a few things related to storing state:

 - It separates `StorageKeys` by type and automatically clears all keys rather than relying on each being manually added to `clearContext`. This had been a common source of bugs.
 - It resets app language to device language on clearing app data
