### PR TITLE
#561 - Force LTR dropdown value to follow RTL setting

### DIFF
--- a/src/components/atoms/dropdown/basic.tsx
+++ b/src/components/atoms/dropdown/basic.tsx
@@ -8,6 +8,7 @@ import {DropdownModal} from './modal';
 
 import {text, colors} from 'theme';
 import {AppIcons} from 'assets/icons';
+import { directionChar } from 'services/i18n/common';
 
 export interface DropdownProps {
   label?: string;
@@ -73,6 +74,9 @@ export const Dropdown = forwardRef<TouchableWithoutFeedback, DropdownProps>(
         selectedItem.label;
     }
 
+    // Force LTR text in RTL mode to RTL orientation
+    const alignedDisplayValue = `${directionChar}${displayValue}`;
+
     return (
       <>
         <TouchableWithoutFeedback
@@ -100,7 +104,7 @@ export const Dropdown = forwardRef<TouchableWithoutFeedback, DropdownProps>(
                 maxFontSizeMultiplier={1.5}
                 numberOfLines={1}
                 style={styles.displayValue}>
-                {displayValue}
+                {alignedDisplayValue}
               </Text>
             </View>
             <AppIcons.ArrowRight width={18} height={18} color={colors.purple} />


### PR DESCRIPTION
For #561

If a dropdown is displaying LTR content (e.g. county names, age ranges) when the app is set to an RTL language, this forces the value to display as RTL and right-align. Without this it either left-aligns contrasting with the other items or disappears entirely.

<img width=300 src="https://user-images.githubusercontent.com/29628323/98758093-d7bdc600-23c5-11eb-96e3-be006820a916.jpg" /> <img width=300 src="https://user-images.githubusercontent.com/29628323/98758199-1d7a8e80-23c6-11eb-95bc-d134ee5e6355.jpg" />