### PR TITLE
#565 - Make share app label view flex

### DIFF
--- a/src/components/views/settings/metrics.tsx
+++ b/src/components/views/settings/metrics.tsx
@@ -30,7 +30,7 @@ export const Metrics = () => {
       <Spacing s={32} />
       <View style={styles.row}>
         <View style={styles.label} accessibilityElementsHidden>
-          <Text>{t('metrics:share')}</Text>
+          <Text style={text.largeBold}>{t('metrics:share')}</Text>
         </View>
         <View>
           <Switch
@@ -68,7 +68,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between'
   },
   label: {
-    ...text.largeBold,
     flex: 1
   }
 });

--- a/src/components/views/settings/metrics.tsx
+++ b/src/components/views/settings/metrics.tsx
@@ -29,8 +29,8 @@ export const Metrics = () => {
       <DataProtectionLink />
       <Spacing s={32} />
       <View style={styles.row}>
-        <View accessibilityElementsHidden>
-          <Text style={styles.label}>{t('metrics:share')}</Text>
+        <View style={styles.label} accessibilityElementsHidden>
+          <Text>{t('metrics:share')}</Text>
         </View>
         <View>
           <Switch


### PR DESCRIPTION
For #565 

Moves flex onto accessible view wrapper around label so it doesn't push the switch off the screen