### PR TITLE
Fix possible crashes on switching RTL/LTR during deleting data 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -430,7 +430,8 @@ function Navigation({
       return;
     }
 
-    if (navigationRef.current && notification) {
+    // Navigate from alert when ready, if user didn't delete data before opening notification
+    if (app.user && navigationRef.current && notification) {
       navigationRef.current.reset(covidAlertReset);
 
       setState((s) => ({...s, notification: null}));
@@ -442,9 +443,13 @@ function Navigation({
       return;
     }
 
-    if (navigationRef.current && exposureNotificationClicked) {
+    if (!app.loading && navigationRef.current && exposureNotificationClicked) {
       console.log('exposureNotificationClicked', exposureNotificationClicked);
-      navigationRef.current.reset(covidAlertReset);
+      if (app.user) {
+        navigationRef.current.reset(covidAlertReset);
+      }
+      // Clear exposureNotificationClicked after loading even if !app.user: if user deleted data
+      // it stays in Android intent and can be re-read if the React Native JS alone restarts.
       setState((s) => ({...s, exposureNotificationClicked: null}));
     }
   }, [app, exposureNotificationClicked]);

--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -4,6 +4,7 @@ import {useNavigation} from '@react-navigation/native';
 import {View, Text, StyleSheet, Alert} from 'react-native';
 import {useExposure} from 'react-native-exposure-notification-service';
 import * as SecureStore from 'expo-secure-store';
+import PushNotification from 'react-native-push-notification';
 
 import {ScreenNames} from 'navigation';
 import {register} from 'services/api';
@@ -74,6 +75,10 @@ export const Permissions: FC<any> = () => {
       });
 
       app.hideActivityIndicator();
+
+      // If app is uninstalled with an active notification, on iOS can stay and be hard to clear
+      // Any notifications on register will be from a previous registration and therefore obsolete
+      PushNotification.setApplicationIconBadgeNumber(0);
 
       if (skip) {
         nav.reset({

--- a/src/components/views/settings/leave.tsx
+++ b/src/components/views/settings/leave.tsx
@@ -4,9 +4,8 @@ import {useTranslation} from 'react-i18next';
 import * as Haptics from 'expo-haptics';
 import {NavigationProp} from '@react-navigation/native';
 import {useExposure} from 'react-native-exposure-notification-service';
+import RNRestarter from 'react-native-restart';
 
-import {ScreenNames} from 'navigation';
-import {getDeviceLanguage} from 'services/i18n';
 import {forget, networkError} from 'services/api';
 import {useApplication} from 'providers/context';
 
@@ -17,7 +16,7 @@ import {PinnedBottom} from 'components/templates/pinned';
 import {DataProtectionLink} from 'components/views/data-protection-policy';
 
 export const Leave: FC<{navigation: NavigationProp<any>}> = ({navigation}) => {
-  const {t, i18n} = useTranslation();
+  const {t} = useTranslation();
   const app = useApplication();
   const exposure = useExposure();
   const confirmed = async () => {
@@ -25,21 +24,15 @@ export const Leave: FC<{navigation: NavigationProp<any>}> = ({navigation}) => {
     try {
       try {
         await exposure.deleteAllData();
-        exposure.stop();
+        await exposure.stop();
       } catch (err) {
         console.log(err);
       }
-      await forget();
       await app.clearContext();
-      i18n.changeLanguage(getDeviceLanguage());
+      await forget();
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
-      app.hideActivityIndicator();
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-
-      navigation.reset({
-        index: 0,
-        routes: [{name: ScreenNames.AgeCheck}]
-      });
+      RNRestarter.Restart();
     } catch (e) {
       app.hideActivityIndicator();
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/src/components/views/settings/leave.tsx
+++ b/src/components/views/settings/leave.tsx
@@ -5,6 +5,7 @@ import * as Haptics from 'expo-haptics';
 import {NavigationProp} from '@react-navigation/native';
 import {useExposure} from 'react-native-exposure-notification-service';
 import RNRestarter from 'react-native-restart';
+import PushNotification from 'react-native-push-notification';
 
 import {forget, networkError} from 'services/api';
 import {useApplication} from 'providers/context';
@@ -31,6 +32,8 @@ export const Leave: FC<{navigation: NavigationProp<any>}> = ({navigation}) => {
       await app.clearContext();
       await forget();
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+
+      PushNotification.setApplicationIconBadgeNumber(0);
 
       RNRestarter.Restart();
     } catch (e) {


### PR DESCRIPTION
For https://github.com/covid-alert-ny/covid-green-app/issues/575 - the good news is after checking thoroughly it doesn't seem to be caused by an issue in RNENS or anything which might affect a user doing common actions.

There are two things going on behind that issue:

 - There were some non-awaited async operations in app leave as well as a potential navigation and app reset at the same time if the user was in a language with different text direction to the device. Either could cause a JS error, and the non-awaited ENS operations could cause a Check Exposure Keys to start which then can't complete.
 - The flashing alert screen is caused by the Android notification intent persisting when only the inner React Native javascript restarts.

I've also ported over a fix for a rare iOS issue where the app badge gets stuck on seen in another app.