### PR TITLE
#601 - Better deep links for unregistered users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,11 @@
 import React, {Suspense, useEffect, useState} from 'react';
 import {enableScreens} from 'react-native-screens';
-import {Platform, StatusBar, Image, AppState, Linking} from 'react-native';
-import {getStateFromPath, NavigationContainer} from '@react-navigation/native';
+import {Platform, StatusBar, Image, AppState} from 'react-native';
+import {
+  getStateFromPath,
+  LinkingOptions,
+  NavigationContainer
+} from '@react-navigation/native';
 import {
   createStackNavigator,
   CardStyleInterpolators
@@ -405,12 +409,14 @@ const MainStack = () => {
   );
 };
 
-const linking = {
+const linking: LinkingOptions = {
   prefixes: [DEEP_LINK_PREFIX, DEEP_LINK_DOMAIN],
   config: {
-    [ScreenNames.UploadKeys]: {
-      path: '/v'
-      // query string params are passed direct to the route as params
+    screens: {
+      [ScreenNames.UploadKeys]: {
+        path: '/v'
+        // query string params are passed direct to the route as params
+      }
     }
   },
   getStateFromPath: (path: string, config: any) => {

--- a/src/components/views/dashboard.tsx
+++ b/src/components/views/dashboard.tsx
@@ -9,6 +9,7 @@ import {
 import {useFocusEffect, useIsFocused} from '@react-navigation/native';
 import {useTranslation} from 'react-i18next';
 
+import {ScreenNames} from 'navigation';
 import {useApplication} from 'providers/context';
 import {useAppState} from 'hooks/app-state';
 import {useSymptomChecker} from 'hooks/symptom-checker';
@@ -37,6 +38,8 @@ export const Dashboard: FC<any> = ({navigation}) => {
     loadAppData,
     data,
     county,
+    pendingCode,
+    setContext,
     setCountyScope
   } = useApplication();
   const {t} = useTranslation();
@@ -79,7 +82,21 @@ export const Dashboard: FC<any> = ({navigation}) => {
     });
   };
 
-  useEffect(onRefresh, []);
+  useEffect(() => {
+    if (pendingCode) {
+      setContext({pendingCode: null});
+      navigation.reset({
+        index: 1,
+        routes: [
+          {name: 'main', params: {screen: ScreenNames.MyCovidAlerts}},
+          {name: ScreenNames.UploadKeys, params: {c: pendingCode}}
+        ]
+      });
+    }
+
+    onRefresh();
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */ // Only run this when screen first mounts
+  }, []);
 
   const errorToast = (data === null || loadError) && (
     <Toast

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -178,15 +178,17 @@ export const UploadKeys: FC<{
   );
 
   useEffect(() => {
-    if (
-      (!ignore6DigitCode && code.length === 6) ||
-      CODE_INPUT_LENGTHS.includes(code.length)
-    ) {
-      codeValidationHandler(code.length === 6);
-    } else {
-      setValidationError('');
+    if (isRegistered) {
+      if (
+        (!ignore6DigitCode && code.length === 6) ||
+        CODE_INPUT_LENGTHS.includes(code.length)
+      ) {
+        codeValidationHandler(code.length === 6);
+      } else {
+        setValidationError('');
+      }
     }
-  }, [ignore6DigitCode, code, codeValidationHandler]);
+  }, [ignore6DigitCode, code, codeValidationHandler, isRegistered]);
 
   const uploadDataHandler = async () => {
     let exposureKeys;

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -5,6 +5,7 @@ import {useTranslation} from 'react-i18next';
 import {NavigationProp, RouteProp} from '@react-navigation/native';
 import {useExposure} from 'react-native-exposure-notification-service';
 
+import {ScreenNames} from 'navigation';
 import {useApplication, SecureStoreKeys} from 'providers/context';
 import {useSettings} from 'providers/settings';
 import {
@@ -40,19 +41,26 @@ export const UploadKeys: FC<{
   navigation: NavigationProp<any>;
   route: RouteProp<any, any>;
 }> = ({navigation, route}) => {
-  const paramsCode = route.params?.c || '';
-
   const {t} = useTranslation();
   const {getDiagnosisKeys} = useExposure();
-  const {showActivityIndicator, hideActivityIndicator} = useApplication();
+  const {
+    showActivityIndicator,
+    hideActivityIndicator,
+    pendingCode,
+    setContext,
+    user
+  } = useApplication();
   const {
     appConfig: {ignore6DigitCode}
   } = useSettings();
 
   const [status, setStatus] = useState<UploadStatus>('initialising');
 
-  const [code, setCode] = useState(paramsCode);
-  const [previousParamsCode, setPreviousParamsCode] = useState(paramsCode);
+  const paramsCode = route.params?.c;
+  const presetCode = paramsCode || pendingCode || '';
+
+  const [code, setCode] = useState(presetCode);
+  const [previousPresetCode, setPreviousPresetCode] = useState(presetCode);
 
   const [validationError, setValidationError] = useState<string>('');
   const [uploadToken, setUploadToken] = useState('');
@@ -61,6 +69,8 @@ export const UploadKeys: FC<{
     timeout: 1000,
     count: 2
   });
+
+  const isRegistered = !!user;
 
   useEffect(() => {
     const readUploadToken = async () => {
@@ -82,17 +92,23 @@ export const UploadKeys: FC<{
       setStatus('validate');
     };
     readUploadToken();
+
+    if (!isRegistered && paramsCode && !pendingCode) {
+      // Store code so we can bring new user back with it they onboard
+      setContext({pendingCode: paramsCode});
+    }
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */ // Run this only once
   }, []);
 
   useEffect(() => {
     // Apply new params code if deep link used while screen is already open
-    if (paramsCode !== previousParamsCode) {
-      setPreviousParamsCode(paramsCode);
-      if (paramsCode) {
-        setCode(paramsCode);
+    if (presetCode !== previousPresetCode) {
+      setPreviousPresetCode(presetCode);
+      if (presetCode) {
+        setCode(presetCode);
       }
     }
-  }, [paramsCode, previousParamsCode]);
+  }, [presetCode, previousPresetCode]);
 
   const codeValidationHandler = useCallback(
     async (ignoreError: boolean) => {
@@ -206,8 +222,8 @@ export const UploadKeys: FC<{
       CODE_INPUT_LENGTHS.find((l) => l === code.length) ||
       CODE_INPUT_LENGTHS[0];
 
-    // Remount and clear input if a new paramsCode is provided
-    const inputKey = `code-input-${previousParamsCode}`;
+    // Remount and clear input if a new presetCode is provided
+    const inputKey = `code-input-${previousPresetCode}`;
 
     return (
       <View key={inputKey}>
@@ -295,6 +311,14 @@ export const UploadKeys: FC<{
       : status === 'error'
       ? renderUploadError()
       : null;
+
+  if (!isRegistered) {
+    navigation.reset({
+      index: 0,
+      routes: [{name: ScreenNames.AgeCheck}]
+    });
+    return null;
+  }
 
   return (
     <KeyboardScrollable

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -63,6 +63,7 @@ interface State {
   callBackQueuedTs?: CallBackQueuedTs;
   accessibility: Accessibility;
   county: County | 'u';
+  pendingCode?: string | null;
 }
 
 export interface ApplicationContextValue extends State {


### PR DESCRIPTION
For https://github.com/covid-alert-ny/covid-green-app/issues/601

It's a bit of an edge case since most unregistered users won't have any close contacts but it's one we should handle for cases like someone who uses another compatible COVID app but is diagnosed via the NYS system and installs the app to use an NYS diagnosis SMS.

- Stores the code and navigates to the upload page when the user completes registration
- Fixes the multiple navigation glitch (which was caused by trying and failing to validate the code while unregistered)
- Fixes a few type warnings