### PR TITLE
Ensure data errors are treated as errors

### DIFF
--- a/src/services/api/connection.ts
+++ b/src/services/api/connection.ts
@@ -155,7 +155,7 @@ export async function requestWithCache<T extends unknown>(
 
     return {
       data,
-      error
+      error: error instanceof Error ? error : new Error(error)
     };
   }
 }


### PR DESCRIPTION
For this comment https://github.com/covid-alert-ny/covid-green-app/issues/607#issuecomment-755829158 on QA testing of the new data caching. 

For some reason the `catch` block in `requestWithCache` was getting a string, not an `Error`, so the components weren't showing the expected error notices.