### PR TITLE
Add code upload button and improve a11y

### DIFF
--- a/src/components/atoms/progress.tsx
+++ b/src/components/atoms/progress.tsx
@@ -48,6 +48,6 @@ const styles = StyleSheet.create({
     width: '100%',
     flex: 1,
     borderRadius: 6.5,
-    backgroundColor: colors.darkerpurple
+    backgroundColor: colors.yellow
   }
 });

--- a/src/components/molecules/single-code-input.tsx
+++ b/src/components/molecules/single-code-input.tsx
@@ -74,6 +74,7 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
       <TextInput
         ref={inputRef}
         selectTextOnFocus
+        autoFocus={true}
         autoCapitalize="characters"
         style={[
           styles.input,
@@ -87,7 +88,6 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
         textContentType={Platform.OS === 'ios' ? 'oneTimeCode' : 'none'}
         editable={!disabled}
         value={value}
-        placeholder={'_'.repeat(count)}
         onFocus={onFocusHandler}
         onChangeText={onChangeTextHandler}
         accessibilityLabel={accessibilityLabel}

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -32,10 +32,8 @@ export const colors = {
   empty: {
     border: '#eeeeee'
   },
-  yellow: '#FFEA0C', // review & remove,
-  lightpurple: '#fff37a',
-  mildpurple: '#fff16f',
-  darkerpurple: '#FFDA1A', // review & merge to purple
+  yellow: '#FFDA1A', // review - only in unused <Progress>
+  softPurple: `${purple}1E`, // translucent, same as outer bubble icon SVG
   orange: '#FF8248',
   lightOrange: '#FFC0A3',
   white,
@@ -76,4 +74,4 @@ export const colors = {
       shadow: 'transparent'
     }
   }
-};
+} as const;

--- a/src/hooks/accessibility.tsx
+++ b/src/hooks/accessibility.tsx
@@ -11,12 +11,12 @@ interface FocusRefProps {
 
 export function setAccessibilityFocusRef(ref: RefObject<any>) {
   if (ref.current) {
-    const tag = findNodeHandle(ref.current);
-    tag &&
-      setTimeout(
-        () => ref.current && AccessibilityInfo.setAccessibilityFocus(tag),
-        250
-      );
+    setTimeout(() => {
+      const tag = ref.current && findNodeHandle(ref.current);
+      if (tag) {
+        AccessibilityInfo.setAccessibilityFocus(tag);
+      }
+    }, 250);
   }
 }
 


### PR DESCRIPTION
This is intended to help smooth the 6 digit to 8 digit transition and also fixes some a11y issues I found while testing.

With this:

 - If a user enters a valid code, it is accepted automatically as before (so the feature does not in any way become harder to use), and "next" is shown automatically as before without interrupting them with a spinner
 - When a user presses the new submit button, the spinner is shown, the current code is validated and validation errors are shown. This way we can more clearly test codes of any length and a user who makes a mistake can more easily spot and correct it.

It uses the existing arrow icon and a11y label for existing "OK" translation so no new text is needed.

I've made a few other small changes based on a11y-testing the new feature:

 - The `_ _ _ _ _ _ _ _` placeholders are removed since TalkBack unhelpfully reads them out and they don't correspond very smoothly to the text input.
 - The text input field is auto-focused to ensure the user can't not realise it's an input field without the placeholder
 - A source of possible Android a11y-focus crashes is removed (though I suspect these were only possible during development)
 - The spacing of the text input characters is based on the actual width available to ensure it fits on small devices, a11y device zoom etc

<img width=320 src="https://user-images.githubusercontent.com/29628323/104948572-6c8c0380-59b5-11eb-9355-4ad205e07071.jpg" /> <img width=320 src="https://user-images.githubusercontent.com/29628323/104948577-6dbd3080-59b5-11eb-98a6-ec76e2313354.jpg" /> <img width=320 src="https://user-images.githubusercontent.com/29628323/104948575-6dbd3080-59b5-11eb-9c89-218a35257db9.jpg" /> <img width=320 src="https://user-images.githubusercontent.com/29628323/104949108-53378700-59b6-11eb-9613-086dba9b8e6b.jpg" />
