### PR TITLE
Fix paste and manual input of long upload codes

### DIFF
--- a/src/components/molecules/single-code-input.tsx
+++ b/src/components/molecules/single-code-input.tsx
@@ -16,12 +16,15 @@ import {scale, text, colors} from 'theme';
 interface SingleCodeInputProps extends AccessibilityProps {
   error?: boolean;
   style?: ViewStyle;
-  count: number;
   disabled?: boolean;
   autoFocus?: boolean;
   onChange?: (value: string) => void;
   code?: string;
 }
+
+export const CODE_INPUT_LENGTHS = [8, 16];
+
+const count = CODE_INPUT_LENGTHS[CODE_INPUT_LENGTHS.length - 1];
 
 export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
   style,
@@ -29,7 +32,6 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
   autoFocus = false,
   onChange,
   error,
-  count,
   accessibilityHint,
   accessibilityLabel,
   code = ''
@@ -71,7 +73,8 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
     }
   };
 
-  const hasLongCode = count > 10;
+  const hasLongCode = code.length > CODE_INPUT_LENGTHS[0];
+  const nextLength = CODE_INPUT_LENGTHS.find((l) => l >= code.length) || count;
 
   const onLayoutHandler = ({
     nativeEvent: {
@@ -85,7 +88,7 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
   const spacePerChar = scale(hasLongCode ? 14 : 26);
   const letterSpacing = Math.max(
     0,
-    (containerWidth - count * spacePerChar) / (count + 1)
+    (containerWidth - nextLength * spacePerChar) / (nextLength + 1)
   );
 
   return (

--- a/src/components/molecules/single-code-input.tsx
+++ b/src/components/molecules/single-code-input.tsx
@@ -51,7 +51,12 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
   }, [inputRef, autoFocus]);
 
   const onChangeTextHandler = (v: string) => {
-    const validatedValue = v.replace(/[^0-9]/g, '');
+    // 16-digit codes are alphanumeric: commenting out to allow their copy-paste
+    // const validatedValue = v.replace(/[^0-9]/g, '');
+
+    // autoCapitalize rarely works on Android; longstanding RN bug
+    const validatedValue = `${v}`.toUpperCase();
+
     setValue(validatedValue);
 
     if (!validatedValue) {
@@ -73,7 +78,7 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
     }
   };
 
-  const hasLongCode = code.length > CODE_INPUT_LENGTHS[0];
+  const hasLongCode = code.length && code.length > CODE_INPUT_LENGTHS[0];
   const nextLength = CODE_INPUT_LENGTHS.find((l) => l >= code.length) || count;
 
   const onLayoutHandler = ({
@@ -105,7 +110,7 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
           error ? styles.errorBlock : styles.block
         ]}
         maxLength={count}
-        keyboardType="number-pad"
+        keyboardType={hasLongCode ? 'ascii-capable' : 'number-pad'}
         returnKeyType="done"
         textContentType={Platform.OS === 'ios' ? 'oneTimeCode' : 'none'}
         editable={!disabled}

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -17,7 +17,10 @@ import {
 import {Spacing} from 'components/atoms/layout';
 import {Button} from 'components/atoms/button';
 import {Markdown} from 'components/atoms/markdown';
-import {SingleCodeInput} from 'components/molecules/single-code-input';
+import {
+  SingleCodeInput,
+  CODE_INPUT_LENGTHS
+} from 'components/molecules/single-code-input';
 import {Toast} from 'components/atoms/toast';
 import {ResultCard} from 'components/molecules/result-card';
 import {KeyboardScrollable} from 'components/templates/keyboard-scrollable';
@@ -34,8 +37,6 @@ type UploadStatus =
   | 'success'
   | 'permissionError'
   | 'error';
-
-const CODE_INPUT_LENGTHS = [8, 16];
 
 export const UploadKeys: FC<{
   navigation: NavigationProp<any>;
@@ -225,11 +226,6 @@ export const UploadKeys: FC<{
   };
 
   const renderValidation = () => {
-    // Use default code length unless a longer code was inserted e.g. by deep link
-    const count =
-      CODE_INPUT_LENGTHS.find((l) => l === code.length) ||
-      CODE_INPUT_LENGTHS[0];
-
     // Remount and clear input if a new presetCode is provided
     const inputKey = `code-input-${previousPresetCode}`;
 
@@ -250,7 +246,6 @@ export const UploadKeys: FC<{
               error={!!validationError}
               onChange={updateCode}
               disabled={status !== 'validate'}
-              count={count}
               accessibilityHint={t('uploadKeys:code:hint')}
               accessibilityLabel={t('uploadKeys:code:label')}
               code={code}


### PR DESCRIPTION
- Allows 16-digit codes to be manually typed, changing the presentation style to smaller numbers on the 9th character (and back again when down to 8)
- Fixes copy-paste of 16-digit codes