### PR TITLE
Show network error text on upload while offline

### DIFF
--- a/src/services/api/connection.ts
+++ b/src/services/api/connection.ts
@@ -7,6 +7,7 @@ import {isMountedRef, navigationRef, ScreenNames} from '../../navigation';
 
 import {urls} from 'constants/urls';
 import {SecureStoreKeys} from 'providers/context';
+import {networkError} from '.';
 
 // Strip any trailing '/' if there is one
 const match = urls.api.match(/^(.*?)\/?$/);
@@ -85,6 +86,10 @@ export const request = async (url: string, cfg: any) => {
     isUnauthorised = resp && resp.status === 401;
   } catch (e) {
     if (!authorizationHeaders || e.status !== 401) {
+      const issue = await identifyNetworkIssue();
+      if (issue.split(':')[0] === '1012') {
+        throw new Error(networkError);
+      }
       throw e;
     }
     isUnauthorised = true;


### PR DESCRIPTION
For https://github.com/covid-alert-ny/covid-green-app/issues/617

Previously we had a `connected()` function which threw `networkError` if netinfo believed we were not connected at the start of a request. This makes sure the same error is thrown which is listened for various places including upload code validation.