### PR TITLE
Make code length message match settings

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -372,7 +372,7 @@
   "uploadKeys": {
     "title": "Share Your Close Contact Codes",
     "code": {
-      "intro": "Please enter the 8-digit number that the public health representative has given you over the phone or texted to you:",
+      "intro": "Please enter the {{length}} number that the public health representative has given you over the phone or texted to you:",
       "hint": "Insert code",
       "label": "Code input",
       "expiredError": "Code has expired. Contact DOH to request another one.",

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -241,7 +241,7 @@ export const UploadKeys: FC<{
       <View key={inputKey}>
         <Markdown markdownStyles={{block: {marginBottom: 24}}}>
           {t('uploadKeys:code:intro', {
-            length: ignore6DigitCode || true ? '8-digit' : '6 or 8 digit'
+            length: ignore6DigitCode ? '8-digit' : '6 or 8 digit'
           })}
         </Markdown>
         <View style={styles.row}>

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -240,7 +240,9 @@ export const UploadKeys: FC<{
     return (
       <View key={inputKey}>
         <Markdown markdownStyles={{block: {marginBottom: 24}}}>
-          {t('uploadKeys:code:intro')}
+          {t('uploadKeys:code:intro', {
+            length: ignore6DigitCode || true ? '8-digit' : '6 or 8 digit'
+          })}
         </Markdown>
         <View style={styles.row}>
           <View style={styles.flex}>


### PR DESCRIPTION
For https://github.com/covid-alert-ny/covid-green-app/issues/616

No text for 16-digit codes since they aren't entered manually