### PR TITLE
Fix x4 upload and feedback QA issues

### DIFF
--- a/src/assets/icons/index.tsx
+++ b/src/assets/icons/index.tsx
@@ -1,3 +1,4 @@
+import {SvgProps} from 'react-native-svg';
 import React, {FC} from 'react';
 import {I18nManager, Platform, View, ViewStyle} from 'react-native';
 
@@ -69,16 +70,12 @@ import SeparateBathroom from './how-to-keep-others-safe/separate-bathroom.svg';
 import GetTested from './how-to-keep-others-safe/get-tested.svg';
 import CallHotline from './how-to-keep-others-safe/call-hotline.svg';
 
-const flipStyle = {
+const flipStyle: ViewStyle = {
   transform: [{scaleX: -1}]
-} as ViewStyle;
-
-interface FlipIconProps {
-  style?: ViewStyle;
-}
+};
 
 const getRtlFlipIcon = (Icon: FC) => {
-  const RtlFlipIcon: FC<FlipIconProps> = ({style, ...iconProps}) =>
+  const RtlFlipIcon: FC<SvgProps> = ({style, ...iconProps}) =>
     I18nManager.isRTL ? (
       <View style={[flipStyle, style]}>
         <Icon {...iconProps} />

--- a/src/components/molecules/single-code-input.tsx
+++ b/src/components/molecules/single-code-input.tsx
@@ -49,11 +49,7 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
   } = useApplication();
 
   const onChangeTextHandler = (v: string) => {
-    // 16-digit codes are alphanumeric: commenting out to allow their copy-paste
-    // const validatedValue = v.replace(/[^0-9]/g, '');
-
-    // autoCapitalize rarely works on Android; longstanding RN bug
-    const validatedValue = `${v}`.toUpperCase();
+    const validatedValue = v.replace(/\s/g, '');
 
     setValue(validatedValue);
 

--- a/src/components/molecules/single-code-input.tsx
+++ b/src/components/molecules/single-code-input.tsx
@@ -101,13 +101,13 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
     (containerWidth - paddedLength * cappedSpacePerChar) / paddedLength
   );
 
+  const isIos = Platform.OS === 'ios';
   return (
     <View style={[styles.container, style]} onLayout={onLayoutHandler}>
       <TextInput
         ref={inputRef}
         selectTextOnFocus
         autoFocus={!screenReaderEnabled}
-        autoCapitalize="characters"
         style={[
           styles.input,
           hasLongCode ? styles.inputLong : styles.inputShort,
@@ -122,10 +122,11 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
           }
         }}
         maxLength={count}
-        keyboardType={hasLongCode ? 'ascii-capable' : 'number-pad'}
+        keyboardType={isIos ? 'ascii-capable' : 'visible-password'}
+        secureTextEntry={!isIos}
         returnKeyType="done"
         blurOnSubmit={true}
-        textContentType={Platform.OS === 'ios' ? 'oneTimeCode' : 'none'}
+        textContentType={isIos ? 'oneTimeCode' : 'none'}
         editable={!disabled}
         value={value}
         onFocus={onFocusHandler}

--- a/src/components/views/settings/feedback.tsx
+++ b/src/components/views/settings/feedback.tsx
@@ -14,8 +14,7 @@ import {
   useExposure,
   StatusState,
   PermissionStatus,
-  getVersion,
-  Version
+  getVersion
 } from 'react-native-exposure-notification-service';
 
 import {Card} from 'components/atoms/card';
@@ -27,7 +26,7 @@ import {text} from 'theme';
 
 export const Feedback = () => {
   const {t} = useTranslation();
-  const [version, setVersion] = useState<Version>();
+  const [version, setVersion] = useState<String>('unavailable');
 
   const {
     canSupport,
@@ -42,14 +41,15 @@ export const Feedback = () => {
     const getVer = async () => {
       try {
         const ver = await getVersion();
-        setVersion(ver);
+        if (ver?.display) {
+          setVersion(ver.display);
+        }
       } catch (err) {
         console.log('Error getting version:', err);
       }
     };
     getVer();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getVersion]);
+  }, []);
 
   const openEmail = (subject: string) =>
     Linking.openURL(
@@ -62,7 +62,7 @@ export const Feedback = () => {
 
 
 Please do not remove. This info helps the technical team assist you
-App Version: ${version?.display}
+App Version: ${version}
 Device: ${getModel()}
 OS version: ${Platform.OS} ${Platform.Version}
 Closeness sensing status: ${

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -270,7 +270,7 @@ export const UploadKeys: FC<{
               activeOpacity={0.8}
               accessibilityRole="button"
               accessibilityLabel={t('common:ok:label')}>
-              {['upload', 'uploadOnly'].includes(status) ? (
+              {status === 'upload' ? (
                 <AppIcons.Success
                   width={24}
                   height={24}
@@ -296,7 +296,7 @@ export const UploadKeys: FC<{
             </Text>
           </>
         )}
-        <Spacing s={16} />
+        <Spacing s={status === 'upload' ? 16 : 96} />
       </View>
     );
   };
@@ -371,7 +371,7 @@ export const UploadKeys: FC<{
 
   return (
     <KeyboardScrollable
-      safeArea={false}
+      safeArea={true}
       headingShort
       backgroundColor={colors.background}
       heading={t('uploadKeys:title')}


### PR DESCRIPTION
This PR has several small issues, there's also one or two more iOS issues that will be done separately. 

By commit:

 - https://github.com/covid-alert-ny/covid-green-app/issues/628 keyboard covering input
 - Fixes some type warnings on arrow icon props
 - https://github.com/covid-alert-ny/covid-green-app/issues/629 type of keypad changing
 - https://github.com/covid-alert-ny/covid-green-app/issues/630 forces uppercase codes when EN Express codes can contain lowercase
 - https://github.com/covid-alert-ny/covid-green-app/issues/631 [Object object] in feedback email title