### PR TITLE
Fixes for iOS QA issues, don't auto-validate 6-digit codes

### DIFF
--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -127,9 +127,7 @@ export const UploadKeys: FC<{
         code
       );
 
-      if (!ignoreError) {
-        hideActivityIndicator();
-      }
+      hideActivityIndicator();
 
       if (result !== ValidationResult.Valid) {
         let errorMessage;

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -184,7 +184,6 @@ export const UploadKeys: FC<{
   useEffect(() => {
     if (isRegistered) {
       if (
-        (!ignore6DigitCode && code.length === 6) ||
         CODE_INPUT_LENGTHS.includes(code.length)
       ) {
         const isPreset = presetCode && code === presetCode;

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -235,7 +235,7 @@ export const UploadKeys: FC<{
       !validationError
     );
 
-    const onDoneHandler = () => setAccessibilityFocusRef(okayRef);
+    const onDoneHandler = () => !okayDisabled && setAccessibilityFocusRef(okayRef);
 
     return (
       <View key={inputKey}>

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -103,6 +103,10 @@ export const UploadKeys: FC<{
       // Store code so we can bring new user back with it they onboard
       setContext({pendingCode: paramsCode});
     }
+
+    // Call hideActivityIndicator on screen dismount: prevent hard-to replicate
+    // bug where screen re-opening from deep link might leave spinner active
+    return hideActivityIndicator;
     /* eslint-disable-next-line react-hooks/exhaustive-deps */ // Run this only once
   }, []);
 

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -33,7 +33,7 @@ export const colors = {
     border: '#eeeeee'
   },
   yellow: '#FFDA1A', // review - only in unused <Progress>
-  softPurple: `${purple}1E`, // translucent, same as outer bubble icon SVG
+  softPurple: '#DCD6E4',
   orange: '#FF8248',
   lightOrange: '#FFC0A3',
   white,


### PR DESCRIPTION
I can't seem to replicate either of these two issues but these changes should have no negative side effects and would fix the only ways I could see these issues coming about:
 
- https://github.com/covid-alert-ny/covid-green-app/issues/618 (error not being read)
- https://github.com/covid-alert-ny/covid-green-app/issues/627
- Button border colour being misapplied on iOS
- Auto-validation of 6-digit codes potentially triggering rate limiting error on 8 digit code if user types quickly