### PR TITLE
Add bluetooth case to covid alerts settings and  a11y fixes

### DIFF
--- a/src/components/atoms/markdown.tsx
+++ b/src/components/atoms/markdown.tsx
@@ -61,6 +61,11 @@ const MarkdownLink = (
           });
         };
 
+    // For screenreaders, read tel numbers as "one two three" not "one hundred and..."
+    const accessibilityLabel = isTel
+      ? href.replace(/\D/g, '').split('').join(' ')
+      : childrenAsText(children);
+
     return screenReaderEnabled ? (
       // we can't use TouchableWithoutFeedback because is not selectable by keyboard tab navigation
       <TouchableOpacity
@@ -69,7 +74,7 @@ const MarkdownLink = (
         accessible={true}
         accessibilityRole="link"
         accessibilityHint={title}
-        accessibilityLabel={childrenAsText(children)}
+        accessibilityLabel={accessibilityLabel}
         onPress={handle}>
         <Text>{children}</Text>
       </TouchableOpacity>

--- a/src/components/molecules/single-code-input.tsx
+++ b/src/components/molecules/single-code-input.tsx
@@ -119,6 +119,8 @@ export const SingleCodeInput: React.FC<SingleCodeInputProps> = ({
         }}
         maxLength={count}
         keyboardType={isIos ? 'ascii-capable' : 'visible-password'}
+        autoCompleteType={'off'}
+        autoCorrect={false}
         secureTextEntry={!isIos}
         returnKeyType="done"
         blurOnSubmit={true}

--- a/src/components/views/settings/contact-tracing.tsx
+++ b/src/components/views/settings/contact-tracing.tsx
@@ -106,7 +106,7 @@ export const ContactTracingSettings: FC = () => {
                 ? askPermissions
                 : gotoSettings
             }>
-            {ensNotAuthorised && !isBluetoothOff 
+            {ensNotAuthorised && !isBluetoothOff
               ? t(`closenessSensing:notAuthorised:${Platform.OS}:setup`)
               : t('settings:status:gotoSettings')}
           </Button>

--- a/src/components/views/settings/contact-tracing.tsx
+++ b/src/components/views/settings/contact-tracing.tsx
@@ -4,7 +4,8 @@ import * as IntentLauncher from 'expo-intent-launcher';
 import {
   useExposure,
   StatusState,
-  AuthorisedStatus
+  AuthorisedStatus,
+  StatusType
 } from 'react-native-exposure-notification-service';
 import {useTranslation} from 'react-i18next';
 
@@ -74,6 +75,8 @@ export const ContactTracingSettings: FC = () => {
     !isServiceActive &&
     (Platform.OS === 'android' || isAuthorised === AuthorisedStatus.unknown);
 
+  const isBluetoothOff = status.type?.indexOf(StatusType.bluetooth) !== -1;
+
   return (
     <KeyboardScrollable
       heading={t('myCovidAlerts:title')}
@@ -89,19 +92,21 @@ export const ContactTracingSettings: FC = () => {
         <>
           <Spacing s={24} />
           <Text style={text.default}>
-            {ensNotAuthorised
-              ? t(`closenessSensing:notAuthorised:${Platform.OS}:text`)
-              : t('settings:status:intro')}
+            {(isBluetoothOff &&
+              t(`closenessSensing:notActive:${Platform.OS}:bt`)) ||
+              (ensNotAuthorised &&
+                t(`closenessSensing:notAuthorised:${Platform.OS}:text`)) ||
+              t('settings:status:intro')}
           </Text>
           <Spacing s={12} />
           <Button
             type="empty"
             onPress={
-              ensNotAuthorised
-                ? async () => await askPermissions()
+              ensNotAuthorised && !isBluetoothOff
+                ? askPermissions
                 : gotoSettings
             }>
-            {ensNotAuthorised
+            {ensNotAuthorised && !isBluetoothOff 
               ? t(`closenessSensing:notAuthorised:${Platform.OS}:setup`)
               : t('settings:status:gotoSettings')}
           </Button>

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -187,9 +187,7 @@ export const UploadKeys: FC<{
 
   useEffect(() => {
     if (isRegistered) {
-      if (
-        CODE_INPUT_LENGTHS.includes(code.length)
-      ) {
+      if (CODE_INPUT_LENGTHS.includes(code.length)) {
         const isPreset = presetCode && code === presetCode;
         codeValidationHandler(!isPreset);
       } else {
@@ -236,8 +234,9 @@ export const UploadKeys: FC<{
       !validationError
     );
 
-    const onDoneHandler = () => (validationError && setAccessibilityFocusRef(errorRef))
-      || (!okayDisabled && setAccessibilityFocusRef(okayRef));
+    const onDoneHandler = () =>
+      (validationError && setAccessibilityFocusRef(errorRef)) ||
+      (!okayDisabled && setAccessibilityFocusRef(okayRef));
 
     return (
       <View key={inputKey}>

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -236,7 +236,8 @@ export const UploadKeys: FC<{
       !validationError
     );
 
-    const onDoneHandler = () => !okayDisabled && setAccessibilityFocusRef(okayRef);
+    const onDoneHandler = () => (validationError && setAccessibilityFocusRef(errorRef))
+      || (!okayDisabled && setAccessibilityFocusRef(okayRef));
 
     return (
       <View key={inputKey}>

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -1,9 +1,7 @@
 import React, {MutableRefObject} from 'react';
 import {NavigationContainerRef} from '@react-navigation/native';
 
-export const isMountedRef = React.createRef<boolean>() as MutableRefObject<
-  boolean
->;
+export const isMountedRef = React.createRef<boolean>() as MutableRefObject<boolean>;
 
 export const navigationRef = React.createRef<NavigationContainerRef | null>() as MutableRefObject<NavigationContainerRef | null>;
 


### PR DESCRIPTION
First three commits are for https://github.com/covid-alert-ny/covid-green-app/issues/635 - my comment there responds to each point

Last non-lint commit is for https://github.com/covid-alert-ny/covid-green-app/issues/634 - there was no "bluetooth off" case in the Settings covid alerts page like there was for the tab. 