### PR TITLE
Prevent validation error seen after validating

### DIFF
--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -56,6 +56,7 @@ export const UploadKeys: FC<{
   } = useSettings();
 
   const [status, setStatus] = useState<UploadStatus>('initialising');
+  const [isValidating, setIsValidating] = useState(false);
 
   const paramsCode = route.params?.c;
   const presetCode = paramsCode || pendingCode || '';
@@ -128,6 +129,7 @@ export const UploadKeys: FC<{
 
   const codeValidationHandler = useCallback(
     async (ignoreError: boolean) => {
+      setIsValidating(true);
       if (!ignoreError) {
         showActivityIndicator();
       }
@@ -167,6 +169,7 @@ export const UploadKeys: FC<{
             setAccessibilityFocusRef(errorRef);
           }, 550);
         }
+        setIsValidating(false);
         return;
       }
 
@@ -176,8 +179,10 @@ export const UploadKeys: FC<{
           SecureStoreKeys.symptomDate,
           newSymptomDate!
         );
+        setIsValidating(false);
       } catch (e) {
         console.log('Error (secure) storing upload token', e);
+        setIsValidating(false);
       }
       setValidationError('');
 
@@ -236,6 +241,7 @@ export const UploadKeys: FC<{
 
     const okayDisabled = !(
       status === 'validate' &&
+      !isValidating &&
       code.length &&
       !validationError
     );

--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -245,6 +245,7 @@ export const UploadKeys: FC<{
       code.length &&
       !validationError
     );
+    const validationDone = status !== 'validate';
 
     const onDoneHandler = () =>
       (validationError && setAccessibilityFocusRef(errorRef)) ||
@@ -260,9 +261,9 @@ export const UploadKeys: FC<{
         <View style={styles.row}>
           <View style={styles.flex}>
             <SingleCodeInput
-              error={!!validationError}
+              error={!!validationError && !validationDone}
               onChange={updateCode}
-              disabled={status !== 'validate'}
+              disabled={validationDone}
               accessibilityHint={t('uploadKeys:code:hint')}
               accessibilityLabel={t('uploadKeys:code:label')}
               hasPreset={!!presetCode}


### PR DESCRIPTION
Disables the code input submit button while validation is in progress, which should make it impossible to double-validate a code and to end up with both a validation error and a continue button.

Just in case there is still some way to send a validation twice, this also sets it to not show validation errors if validation has succeeded and the app is ready to upload.