### PR TITLE
Clear SecureStore on app registration

### DIFF
--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -8,7 +8,11 @@ import PushNotification from 'react-native-push-notification';
 
 import {ScreenNames} from 'navigation';
 import {register} from 'services/api';
-import {useApplication, SecureStoreKeys, clearSecureStore} from 'providers/context';
+import {
+  useApplication,
+  SecureStoreKeys,
+  clearSecureStore
+} from 'providers/context';
 import {useFocusRef} from 'hooks/accessibility';
 
 import {Button} from 'components/atoms/button';

--- a/src/components/views/onboarding/permissions.tsx
+++ b/src/components/views/onboarding/permissions.tsx
@@ -8,7 +8,7 @@ import PushNotification from 'react-native-push-notification';
 
 import {ScreenNames} from 'navigation';
 import {register} from 'services/api';
-import {useApplication, SecureStoreKeys} from 'providers/context';
+import {useApplication, SecureStoreKeys, clearSecureStore} from 'providers/context';
 import {useFocusRef} from 'hooks/accessibility';
 
 import {Button} from 'components/atoms/button';
@@ -43,6 +43,9 @@ export const Permissions: FC<any> = () => {
   const handleRegistration = async (skip: boolean) => {
     try {
       app.showActivityIndicator();
+
+      await clearSecureStore(); // Clear anything leftover from uninstall / reinstall
+
       const analyticsOptIn = true;
 
       const {token, refreshToken} = await register();

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -129,6 +129,14 @@ export const SecureStoreKeys = {
   callbackQueued: 'covidApp.callBackQueuedTs'
 } as const;
 
+export const clearSecureStore = async (): Promise<void> => {
+  await Promise.all(
+    Object.values(SecureStoreKeys).map((key) =>
+      SecureStore.deleteItemAsync(key)
+    )
+  );
+};
+
 export const AP = ({appConfig, user, consent, children}: API) => {
   const [state, setState] = useState<State>({
     ...initialState,
@@ -305,9 +313,7 @@ export const AP = ({appConfig, user, consent, children}: API) => {
 
   const clearContext = async (): Promise<void> => {
     await Promise.all([
-      ...Object.values(SecureStoreKeys).map((key) =>
-        SecureStore.deleteItemAsync(key)
-      ),
+      clearSecureStore(),
       ...Object.values(AsyncStorageKeys).map((key) =>
         AsyncStorage.removeItem(key)
       ),


### PR DESCRIPTION
Removes any debris from previous install, like upload tokens saved in secure store, in case a user uninstalled and reinstalled the app without having used "Leave" / "Delete your data".