### PR TITLE
Better universal workaround for iOS spinner bug

### DIFF
--- a/src/components/views/upload-keys.tsx
+++ b/src/components/views/upload-keys.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, useCallback, FC} from 'react';
-import {Text, StyleSheet, View, Platform} from 'react-native';
+import {Text, StyleSheet, View} from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import {useTranslation} from 'react-i18next';
 import {NavigationProp, RouteProp} from '@react-navigation/native';
@@ -67,13 +67,6 @@ export const UploadKeys: FC<{
     count: 3
   });
 
-  // On iOS, spinner can get stuck on forever if hidden too quickly e.g. network error
-  const hideActivityIndicatorSafe = useCallback(() => {
-    Platform.OS === 'ios'
-      ? setTimeout(hideActivityIndicator, 1000)
-      : hideActivityIndicator();
-  }, [hideActivityIndicator]);
-
   const isRegistered = !!user;
 
   const updateCode = useCallback((input: string) => {
@@ -108,7 +101,7 @@ export const UploadKeys: FC<{
     }
 
     // Ensure spinner isn't left running on screen re-mount from reusing deep link
-    return hideActivityIndicatorSafe;
+    return hideActivityIndicator;
     /* eslint-disable-next-line react-hooks/exhaustive-deps */ // Run this only once
   }, []);
 
@@ -131,7 +124,7 @@ export const UploadKeys: FC<{
         code
       );
 
-      hideActivityIndicatorSafe();
+      hideActivityIndicator();
 
       if (result !== ValidationResult.Valid) {
         let errorMessage;
@@ -176,7 +169,7 @@ export const UploadKeys: FC<{
         setAccessibilityFocusRef(uploadRef);
       }, 250);
     } /* eslint-disable-next-line react-hooks/exhaustive-deps */, // errorRef and uploadRef are stable
-    [code, showActivityIndicator, hideActivityIndicatorSafe, t]
+    [code, showActivityIndicator, hideActivityIndicator, t]
   );
 
   useEffect(() => {
@@ -201,12 +194,12 @@ export const UploadKeys: FC<{
     try {
       showActivityIndicator();
       await uploadExposureKeys(uploadToken, symptomDate, exposureKeys);
-      hideActivityIndicatorSafe();
+      hideActivityIndicator();
 
       setStatus('success');
     } catch (err) {
       console.log('error uploading exposure keys:', err);
-      hideActivityIndicatorSafe();
+      hideActivityIndicator();
 
       setStatus('error');
     }

--- a/src/providers/context.tsx
+++ b/src/providers/context.tsx
@@ -3,9 +3,10 @@ import React, {
   useEffect,
   useState,
   useContext,
-  useCallback
+  useCallback,
+  useRef
 } from 'react';
-import {AccessibilityInfo} from 'react-native';
+import {AccessibilityInfo, Platform} from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import {format, compareDesc, startOfDay, subDays, isBefore} from 'date-fns';
@@ -143,6 +144,7 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     checkInConsent: consent === 'y',
     user: (user && JSON.parse(user as string)) || undefined
   });
+  const [spinnerShown, setSpinnerShown] = useState<number | null>(null);
 
   const handleReduceMotionChange = (reduceMotionEnabled: boolean): void => {
     setState((s) => ({
@@ -327,13 +329,32 @@ export const AP = ({appConfig, user, consent, children}: API) => {
     }));
   };
 
-  const showActivityIndicator = (message?: string) => {
+  const showActivityIndicatorRef = useCallback((message?: string) => {
+    if (Platform.OS === 'ios') {
+      setSpinnerShown(Date.now());
+    }
     setState((s) => ({...s, loading: message || true}));
-  };
-  const showActivityIndicatorRef = useCallback(showActivityIndicator, []);
+  }, []);
 
   const hideActivityIndicator = () => setState((s) => ({...s, loading: false}));
-  const hideActivityIndicatorRef = useCallback(hideActivityIndicator, []);
+  // useRef to not re-render components or re-fire useEffects (e.g. send code validation) on spinnerShown change
+  const {current: hideActivityIndicatorRef} = useRef(() => {
+    if (Platform.OS === 'ios' && spinnerShown) {
+      // Avoid react-native-loading-spinner-overlay ios bug (fast show/hide -> spinner never removed)
+      // https://github.com/joinspontaneous/react-native-loading-spinner-overlay/issues/30 (closed not fixed)
+      const minIosSpinnerDurationMs = 1000;
+      const spinnerDurationMs = Date.now() - spinnerShown;
+      setSpinnerShown(null);
+      if (spinnerDurationMs < minIosSpinnerDurationMs) {
+        setTimeout(
+          hideActivityIndicator,
+          minIosSpinnerDurationMs - spinnerDurationMs
+        );
+        return;
+      }
+    }
+    hideActivityIndicator();
+  });
 
   const checkIn = async (
     symptoms: SymptomRecord,


### PR DESCRIPTION
We've seen a few rare issues on iOS where the spinner is never hidden, https://github.com/covid-alert-ny/covid-green-app/pull/639 fixed the only one reported for this app by showing the spinner for an extra second on one screen, but we've seen some others on other apps, and with the latest change that extra second of spinner is more visible in the cases it's not needed and more potentially annoying.

This is a general fix to avoid the problem everywhere, not just in the one screen where that issue was reported. So this should have two advantages:

 - Prevents any other rare occurrences of the bug we haven't yet seen
 - Doesn't add extra spinner time when it isn't needed and the spinner has already spun long enough to avoid triggering the endless spinner