### PR TITLE
Fix chart date matching around months with < 30 days

### DIFF
--- a/src/components/organisms/tracker-charts.tsx
+++ b/src/components/organisms/tracker-charts.tsx
@@ -141,7 +141,7 @@ const getBarchartData = (
 };
 
 const getComparableDate = (date: Date) => {
-  return format(date, 'yyyy-mm-dd');
+  return format(date, 'yyyy-MM-dd');
 };
 
 export const TrackerCharts: FC<TrackerChartsProps> = ({


### PR DESCRIPTION
Fixes bug where positivity calculation is wrong if the previous month had less than 30 days (i.e. wrong for 1st and 2nd March until data for 3rd and 4th March is uploaded).

This is patched up for this year via the API and likely won't have an affect until March 1st 2022 so there's no need to rush out a patch release but it should still be fixed.