### PR TITLE
Delay leave-RTL-restart until ios spinner hidden

### DIFF
--- a/src/components/views/settings/leave.tsx
+++ b/src/components/views/settings/leave.tsx
@@ -38,6 +38,14 @@ export const Leave: FC<{navigation: NavigationProp<any>}> = ({navigation}) => {
       await app.clearContext();
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
+      if (Platform.OS === 'ios' && willRestart) {
+        // Published builds (not local) in this scenario get spinner stuck on forever
+        // Wait until spinner is fully hidden before allowing app to restart
+        app.hideActivityIndicator();
+        setTimeout(() => i18n.changeLanguage(deviceLanguage), 800);
+        return;
+      }
+
       // If language reset changes RTL/LTR, app will restart, no need to navigate
       await i18n.changeLanguage(deviceLanguage);
       if (!willRestart) {


### PR DESCRIPTION
There's a bug we can't replicate in local builds, only in iOS downloaded builds, where on iOS leaving the app while in a different-direction language to the device language causes the spinner to be stuck on forever. Details on https://trello.com/c/pB9tJFhw/134-leave-app-while-in-rtl-language-results-in-forever-spin

Previous attempts to fix iOS spinner issues cleanly backfired, so this is a bit of a brute force fix: in the edge case that has the bug, wait until the spinner is gone and its animation is complete before continuing.