### PR TITLE
Make all text updatable from API, with slots for vaccine info

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -485,6 +485,11 @@
     "stats": {
       "title": "NY COVID Data",
       "subtitle": "How fast is COVID-19 spreading?"
+    },
+    "text": {
+      "top": "",
+      "middle": "",
+      "bottom": "Click on the link to view the New York State Department of Health [Vaccine Tracker](https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker)."
     }
   },
   "positiveResult": {

--- a/src/components/atoms/bar-chart-content.tsx
+++ b/src/components/atoms/bar-chart-content.tsx
@@ -92,7 +92,13 @@ export const BarChartContent: FC<BarChartContentProps> = ({
         if (isNaN(x(index))) {
           return points;
         }
-        return [...points, [(x(index) || 0) + bandwidth / 2, y(value) || 0]];
+        return [
+          ...points,
+          [
+            (x(index) || 0) + bandwidth / 2,
+            (y(value) || 0) + cornerRoundness
+          ]
+        ];
       }, [] as [number, number][])
     );
     return pathDef ? (

--- a/src/components/atoms/dropdown/modal.tsx
+++ b/src/components/atoms/dropdown/modal.tsx
@@ -70,7 +70,7 @@ export const DropdownModal: React.FC<DropdownModalProps> = ({
 
       // On Android, bringing up the keyboard during render causes juddering
       // and can cause sizes to end up incorrectly calculated
-      Platform.OS === 'android' ? setTimeout(focusInput, 400) : focusInput();
+      Platform.OS === 'android' ? setTimeout(focusInput, 800) : focusInput();
     }
     /* eslint-disable-next-line react-hooks/exhaustive-deps */ // run only when modal is mounted
   }, []);

--- a/src/components/atoms/text-block.tsx
+++ b/src/components/atoms/text-block.tsx
@@ -1,0 +1,32 @@
+import React, {FC} from 'react';
+import {View} from 'react-native';
+
+import {Spacing} from 'components/atoms/spacing';
+import {Markdown} from 'components/atoms/markdown';
+
+interface TextBlockProps {
+  text: string;
+  spacing?: number;
+}
+
+export const TextBlock: FC<TextBlockProps> = ({text, spacing = 20}) => {
+  if (!text) {
+    // Skip spacing if text is empty
+    return null;
+  }
+  return (
+    <>
+      <Spacing s={spacing} />
+      <View style={styles.flex}>
+        <Markdown>{text}</Markdown>
+      </View>
+      <Spacing s={spacing} />
+    </>
+  );
+};
+
+const styles = {
+  flex: {
+    flex: 1
+  }
+};

--- a/src/components/views/dashboard.tsx
+++ b/src/components/views/dashboard.tsx
@@ -19,6 +19,7 @@ import {networkError} from 'services/api';
 import {Button} from 'components/atoms/button';
 import {Heading} from 'components/atoms/heading';
 import {Spacing} from 'components/atoms/layout';
+import {TextBlock} from 'components/atoms/text-block';
 import {Toast} from 'components/atoms/toast';
 import {AlertInformation} from 'components/molecules/alert-information';
 import {CheckInCard} from 'components/molecules/check-in-card';
@@ -137,6 +138,7 @@ export const Dashboard: FC<any> = ({navigation}) => {
           <Spacing s={16} />
         </>
       )}
+      <TextBlock text={t('dashboard:text:top')} />
       {!completedChecker && (
         <>
           <CheckInCard
@@ -157,6 +159,7 @@ export const Dashboard: FC<any> = ({navigation}) => {
           </View>
         </>
       )}
+      <TextBlock text={t('dashboard:text:middle')} />
       {data && (
         <>
           <Heading
@@ -180,6 +183,7 @@ export const Dashboard: FC<any> = ({navigation}) => {
           <TrackerCharts data={data} county={county.split('_')[0]} />
         </>
       )}
+      <TextBlock text={t('dashboard:text:bottom')} />
     </Scrollable>
   );
 };


### PR DESCRIPTION
This adds three slots for text on the dashboard, and by default in English shows vaccine info at the bottom:

 - `dashboard.text.top`: Above the check-in card (but not above a close contact alert or toast-type notice)
 - `dashboard.text.middle`: Below the check-in card, above the charts  
 - `dashboard.text.bottom`: Below the charts

This also makes all text updatable from the API by passing a `textOverrides` object with keys for language codes and then items following the same structure as the language .json files. For example, this would change English and Spanish "OK" label, disable the bottom dashboard vaccine info and add one in the middle of the dashboard:

```
"textOverrides": {
  "en": {
    "common": {
      "ok": {
        "label": "Okay"
      },
    "dashboard": {
      "text": {
        "middle": "Try our [Vaccine Tracker](https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker)",
        "bottom": ""
      }
   },
  "es": {
    "common": {
      "ok": {
        "label": "Vale"
      }
  }
}
```

There's also a couple of minor tweaks to line up charts better when values are zero and improve dropdown behaviour on android.